### PR TITLE
Update no-show bowler score from -1 to 0

### DIFF
--- a/source/main/Squads/SquadsRepository.cs
+++ b/source/main/Squads/SquadsRepository.cs
@@ -53,7 +53,7 @@ internal class Repository : IRepository
             {
                 for (short game = 1; game <= games; game++)
                 {
-                    await _dataContext.SquadScores.AddAsync(new Database.Entities.SquadScore { BowlerId = noShow, SquadId = id, Score = -1, Game = game }, cancellationToken).ConfigureAwait(false);
+                    await _dataContext.SquadScores.AddAsync(new Database.Entities.SquadScore { BowlerId = noShow, SquadId = id, Score = 0, Game = game }, cancellationToken).ConfigureAwait(false);
                 }
             }
         }


### PR DESCRIPTION
#### PR Classification
Bug fix: Adjust the score for bowlers who did not show up for a game.

Resolves #61 

#### PR Summary
The code change updates the score for no-show bowlers from -1 to 0.
- Modified the loop handling no-show bowlers to set `SquadScore.Score` to 0 instead of -1.
