### PR TITLE
Lane Registration Sortings

### DIFF
--- a/source/main/LaneAssignments/Retrieve/RetrieveLaneAssignmentsAdapter.cs
+++ b/source/main/LaneAssignments/Retrieve/RetrieveLaneAssignmentsAdapter.cs
@@ -21,7 +21,10 @@ internal class Adapter : IAdapter
     }
 
     async Task<IEnumerable<IViewModel>> IAdapter.ExecuteAsync(SquadId squadId, CancellationToken cancellationToken)
-        => (await _businessLogic.ExecuteAsync(squadId, cancellationToken).ConfigureAwait(false)).Select(laneAssignment => new ViewModel(laneAssignment));
+        => (await _businessLogic.ExecuteAsync(squadId, cancellationToken).ConfigureAwait(false))
+            .OrderBy(laneAssignment => laneAssignment.Bowler.Name.Last)
+            .ThenBy(laneAssignment => laneAssignment.Bowler.Name.First)
+            .Select(laneAssignment => new ViewModel(laneAssignment));
 }
 
 internal interface IAdapter


### PR DESCRIPTION
This pull request includes a change to the `RetrieveLaneAssignmentsAdapter` class to improve the ordering of lane assignments by bowler's last and first names.

Improvements to lane assignment ordering:

* [`source/main/LaneAssignments/Retrieve/RetrieveLaneAssignmentsAdapter.cs`](diffhunk://#diff-713b606ab06cbaa8b03ada0357bf5dcd65b5b9e5473bf7c55e595f6be6afe2fcL24-R27): Modified the `ExecuteAsync` method to order lane assignments by bowler's last name and then by first name before converting them to view models.