### PR TITLE
API Middleware

### DIFF
--- a/.github/workflows/deploy_database.yml
+++ b/.github/workflows/deploy_database.yml
@@ -3,6 +3,7 @@ name: Deploy Database
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 on:
   workflow_dispatch:

--- a/source/Directory.Packages.props
+++ b/source/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="Ardalis.SmartEnum" Version="8.2.0" />
     <PackageVersion Include="Ardalis.SmartEnum.EFCore" Version="8.2.0" />
     <PackageVersion Include="Ardalis.SmartEnum.SystemTextJson" Version="8.1.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.MySql" Version="9.0.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
     <PackageVersion Include="Azure.Identity" Version="1.14.2" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />

--- a/source/api/BogusData/BogusTournamentSummaryDto.cs
+++ b/source/api/BogusData/BogusTournamentSummaryDto.cs
@@ -15,5 +15,8 @@ internal sealed class BogusGetTournamentsDto
         RuleFor(dto => dto.EndDate, (f, dto) => f.Date.FutureDateOnly(refDate: dto.StartDate));
         RuleFor(dto => dto.EntryFee, f => f.Finance.Amount(min: 50, max: 150, decimals: 0));
         RuleFor(dto => dto.BowlingCenter, f => f.Company.CompanyName());
+        RuleFor(dto => dto.FinalsRatio, f => f.Finance.Amount(min: 6, max: 11, decimals: 0));
+        RuleFor(dto => dto.CashRatio, f => f.Finance.Amount(min: 3, max: 4, decimals: 1));
+        RuleFor(dto => dto.SuperSweeperCashRatio, f => f.Finance.Amount(min: 4, max: 6, decimals: 1));
     }
 }

--- a/source/api/BowlingMegabucks.TournamentManager.Api.csproj
+++ b/source/api/BowlingMegabucks.TournamentManager.Api.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.SmartEnum.SystemTextJson" />
+    <PackageReference Include="AspNetCore.HealthChecks.MySql" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />

--- a/source/api/HttpStatusCodeResponses.cs
+++ b/source/api/HttpStatusCodeResponses.cs
@@ -47,6 +47,15 @@ internal static class HttpStatusCodeResponses
             TraceId = "0HMPNHL0JHL76:00000001"
         };
 
+    internal static ProblemDetails SampleTooManyRequests429(string instance)
+        => new()
+        {
+            Status = StatusCodes.Status429TooManyRequests,
+            Instance = instance,
+            TraceId = "0HMPNHL0JHL76:00000001",
+            Detail = "You have exceeded the allowed number of requests. Please try again later."
+        };
+
     internal static ProblemDetails SampleInternalServerError500(string instance)
         => new()
         {

--- a/source/api/Middleware/InMemoryRateLimiterService.cs
+++ b/source/api/Middleware/InMemoryRateLimiterService.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 namespace BowlingMegabucks.TournamentManager.Api.Middleware;
 
 internal sealed class InMemoryRateLimiterService
-    : IRateLimiterService
+    : IRateLimiterService, IDisposable
 {
     private readonly ConcurrentDictionary<string, (int Count, DateTime WindowStart)> _counters = new();
     private readonly Timer _cleanupTimer;
@@ -26,9 +26,8 @@ internal sealed class InMemoryRateLimiterService
     }
 
     public void Dispose()
-    {
-        _cleanupTimer.Dispose();
-    }
+        => _cleanupTimer.Dispose();
+        
     public Task<bool> IsRequestAllowedAsync(string key, int permitLimit, TimeSpan window)
     {
         var now = DateTime.UtcNow;

--- a/source/api/Middleware/InMemoryRateLimiterService.cs
+++ b/source/api/Middleware/InMemoryRateLimiterService.cs
@@ -1,0 +1,34 @@
+using System.Collections.Concurrent;
+
+namespace BowlingMegabucks.TournamentManager.Api.Middleware;
+
+internal sealed class InMemoryRateLimiterService
+    : IRateLimiterService
+{
+    private readonly ConcurrentDictionary<string, (int Count, DateTime WindowStart)> _counters = new();
+
+    public Task<bool> IsRequestAllowedAsync(string key, int permitLimit, TimeSpan window)
+    {
+        var now = DateTime.UtcNow;
+        var (Count, WindowStart) = _counters.GetOrAdd(key, _ => (0, now));
+
+        if (now - WindowStart > window)
+        {
+            _counters[key] = (1, now);
+            return Task.FromResult(true);
+        }
+
+        if (Count < permitLimit)
+        {
+            _counters[key] = (Count + 1, WindowStart);
+            return Task.FromResult(true);
+        }
+
+        return Task.FromResult(false);
+    }
+}
+
+internal interface IRateLimiterService
+{
+    Task<bool> IsRequestAllowedAsync(string key, int permitLimit, TimeSpan window);
+}

--- a/source/api/Middleware/RateLimitingMiddleware.cs
+++ b/source/api/Middleware/RateLimitingMiddleware.cs
@@ -1,0 +1,71 @@
+using System.Collections.Concurrent;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace BowlingMegabucks.TournamentManager.Api.Middleware;
+
+internal sealed class RateLimitingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<RateLimitingMiddleware> _logger;
+    private readonly RateLimitingOptions _options;
+    private readonly IProblemDetailsService _problemDetailsService;
+    private static readonly ConcurrentDictionary<string, TokenBucketRateLimiter> _limiters = new();
+
+    public RateLimitingMiddleware(
+        RequestDelegate next,
+        ILogger<RateLimitingMiddleware> logger,
+        IOptions<RateLimitingOptions> options,
+        IProblemDetailsService problemDetailsService)
+    {
+        _next = next;
+        _logger = logger;
+        _options = options.Value;
+        _problemDetailsService = problemDetailsService;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var ip = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        var limiter = _limiters.GetOrAdd(ip, _ => new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+        {
+            TokenLimit = _options.PermitLimit,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            QueueLimit = 0,
+            ReplenishmentPeriod = TimeSpan.FromSeconds(_options.WindowSeconds),
+            TokensPerPeriod = _options.PermitLimit,
+            AutoReplenishment = true
+        }));
+
+        var lease = await limiter.AcquireAsync(1);
+
+        if (!lease.IsAcquired)
+        {
+            _logger.RateLimitExceeded(ip);
+            context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+
+            await _problemDetailsService.WriteAsync(new ProblemDetailsContext
+            {
+                HttpContext = context,
+                ProblemDetails = new ProblemDetails
+                {
+                    Status = StatusCodes.Status429TooManyRequests,
+                    Title = "Too Many Requests",
+                    Detail = "You have exceeded the allowed number of requests. Please try again later.",
+                    Type = "https://tools.ietf.org/html/rfc6585#section-4"
+                }
+            });
+
+            return;
+        }
+
+        await _next(context);
+    }
+}
+
+internal static partial class RateLimitingLoggerExtensions
+{
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Rate limit exceeded for IP: {IP}", EventName = "RateLimitExceeded")]
+    public static partial void RateLimitExceeded(this ILogger<RateLimitingMiddleware> logger, string ip);
+}

--- a/source/api/Middleware/RequestContextLoggingMiddleware.cs
+++ b/source/api/Middleware/RequestContextLoggingMiddleware.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Primitives;
+
+namespace BowlingMegabucks.TournamentManager.Api.Middleware;
+
+internal sealed class RequestContextLoggingMiddleware
+    : IEndpointFilter
+{
+    private const string _correlationIdHeaderName = "x-correlation-id";
+    private readonly ILogger<RequestContextLoggingMiddleware> _logger;
+
+    public RequestContextLoggingMiddleware(ILogger<RequestContextLoggingMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var correlationId = GetCorrelationId(context.HttpContext);
+
+        using (_logger.BeginScope(new Dictionary<string, object>
+        {
+            ["CorrelationId"] = correlationId
+        }))
+        {
+            return await next(context);
+        }
+    }
+
+    private static string GetCorrelationId(HttpContext context)
+    {
+        context.Request.Headers.TryGetValue(_correlationIdHeaderName, out var correlationId);
+
+        return correlationId.FirstOrDefault() ?? context.TraceIdentifier;
+    }
+}

--- a/source/api/Program.cs
+++ b/source/api/Program.cs
@@ -25,6 +25,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddOpenApi();
 
 builder.Services.Configure<RateLimitingOptions>(builder.Configuration.GetSection("RateLimiting"));
+builder.Services.AddSingleton<IRateLimiterService, InMemoryRateLimiterService>();
 
 builder.Services.AddProblemDetails();
 

--- a/source/api/Program.cs
+++ b/source/api/Program.cs
@@ -123,26 +123,27 @@ if (app.Environment.IsDevelopment())
     await scope.ApplyMigrationsAsync();
 }
 
-    app.UseAuthentication()
-        .UseAuthorization()
-        .UseFastEndpoints(c =>
+app.UseDefaultExceptionHandler()
+    .UseAuthentication()
+    .UseAuthorization()
+    .UseFastEndpoints(c =>
+    {
+        c.Versioning.Prefix = "v";
+        c.Versioning.DefaultVersion = 1;
+        c.Versioning.PrependToRoute = true;
+
+        c.Serializer.Options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+
+        c.Endpoints.ShortNames = true;
+        c.Errors.UseProblemDetails(pd =>
         {
-            c.Versioning.Prefix = "v";
-            c.Versioning.DefaultVersion = 1;
-            c.Versioning.PrependToRoute = true;
+            pd.IndicateErrorCode = true;
+            pd.IndicateErrorSeverity = true;
+        });
 
-            c.Serializer.Options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-
-            c.Endpoints.ShortNames = true;
-            c.Errors.UseProblemDetails(pd =>
-            {
-                pd.IndicateErrorCode = true;
-                pd.IndicateErrorSeverity = true;
-            });
-
-            c.Endpoints.Configurator = endpoints =>
-                endpoints.Options(options => options.AddEndpointFilter<RequestContextLoggingMiddleware>());
-        })
-        .UseSwaggerGen();
+        c.Endpoints.Configurator = endpoints =>
+            endpoints.Options(options => options.AddEndpointFilter<RequestContextLoggingMiddleware>());
+    })
+    .UseSwaggerGen();
 
 await app.RunAsync();

--- a/source/api/Program.cs
+++ b/source/api/Program.cs
@@ -90,7 +90,9 @@ builder.Services.AddOpenTelemetry()
     .WithMetrics(metrics => metrics
         .AddHttpClientInstrumentation()
         .AddAspNetCoreInstrumentation()
-        .AddRuntimeInstrumentation());
+        .AddRuntimeInstrumentation()
+        .AddMeter("Microsoft.AspNetCore.Hosting")
+        .AddMeter("Microsoft.AspNetCore.Server.Kestrel"));
 
 builder.Logging.AddOpenTelemetry(options =>
 {

--- a/source/api/Program.cs
+++ b/source/api/Program.cs
@@ -127,15 +127,18 @@ else
 
 var app = builder.Build();
 
-app.UseOpenApi(c => c.Path = "/openapi/{documentName}.json");
-app.MapScalarApiReference();
-
-if (app.Environment.IsDevelopment())
+if (app.Environment.IsDevelopment() || app.Environment.IsStaging())
 {
-    app.UseHttpsRedirection();
+    app.UseOpenApi(c => c.Path = "/openapi/{documentName}.json");
+    app.MapScalarApiReference();
+    
+    if (app.Environment.IsDevelopment())
+    {
+        app.UseHttpsRedirection();
 
-    using var scope = app.Services.CreateScope();
-    await scope.ApplyMigrationsAsync();
+        using var scope = app.Services.CreateScope();
+        await scope.ApplyMigrationsAsync();
+    }
 }
 
 app.MapHealthChecks("/health", new HealthCheckOptions

--- a/source/api/Program.cs
+++ b/source/api/Program.cs
@@ -15,6 +15,7 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Scalar.AspNetCore;
+using BowlingMegabucks.TournamentManager.Api.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -138,6 +139,9 @@ if (app.Environment.IsDevelopment())
                 pd.IndicateErrorCode = true;
                 pd.IndicateErrorSeverity = true;
             });
+
+            c.Endpoints.Configurator = endpoints =>
+                endpoints.Options(options => options.AddEndpointFilter<RequestContextLoggingMiddleware>());
         })
         .UseSwaggerGen();
 

--- a/source/api/Program.cs
+++ b/source/api/Program.cs
@@ -29,14 +29,6 @@ builder.Services.AddSingleton<IRateLimiterService, InMemoryRateLimiterService>()
 
 builder.Services.AddProblemDetails();
 
-builder.Services.AddHealthChecks()
-    .AddMySql(
-        builder.Configuration.GetConnectionString("Default")
-            ?? throw new InvalidOperationException("Default connection string is not configured."),
-        name: "database",
-        tags: new[] { "db", "sql", "mysql" }
-    );
-
 builder.Services.AddFastEndpoints()
     .AddAuthorization()
     .AddAuthentication(ApiKeyAuthentication.SchemeName)
@@ -97,6 +89,14 @@ if (!string.IsNullOrEmpty(keyVaultUrl))
 {
     builder.Configuration.AddAzureKeyVault(new Uri(keyVaultUrl), new DefaultAzureCredential());
 }
+
+builder.Services.AddHealthChecks()
+    .AddMySql(
+        builder.Configuration.GetConnectionString("Default")
+            ?? throw new InvalidOperationException("Default connection string is not configured."),
+        name: "database",
+        tags: new[] { "db", "sql", "mysql" }
+    );
 
 builder.Services.AddOpenTelemetry()
     .ConfigureResource(resource => resource.AddService(builder.Environment.ApplicationName))

--- a/source/api/RateLimitingOptions.cs
+++ b/source/api/RateLimitingOptions.cs
@@ -1,0 +1,7 @@
+namespace BowlingMegabucks.TournamentManager.Api;
+
+internal sealed class RateLimitingOptions
+{
+    public int PermitLimit { get; set; }
+    public int WindowSeconds { get; set; }
+}

--- a/source/api/Registrations/CreateRegistration/CreateRegistrationEndpoint.cs
+++ b/source/api/Registrations/CreateRegistration/CreateRegistrationEndpoint.cs
@@ -19,9 +19,10 @@ public sealed class CreateRegistrationEndpoint
 
         Description(d => d
             .Produces<CreateRegistrationResponse>(StatusCodes.Status201Created, HttpContentTypes.Json)
-            .Produces<ProblemDetails>(StatusCodes.Status400BadRequest, HttpContentTypes.ProblemJson)
+            .ProducesProblemDetails(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
-            .Produces<ProblemDetails>(StatusCodes.Status500InternalServerError, HttpContentTypes.ProblemJson)
+            .ProducesProblemDetails(StatusCodes.Status429TooManyRequests)
+            .ProducesProblemDetails(StatusCodes.Status500InternalServerError)
             .WithName("Create Registration"));
 
         Summary(s =>
@@ -36,11 +37,13 @@ public sealed class CreateRegistrationEndpoint
                 RegistrationId = RegistrationId.New()
             };
             s.ResponseExamples[StatusCodes.Status400BadRequest] = HttpStatusCodeResponses.SampleBadRequest400("/registrations");
+            s.ResponseExamples[StatusCodes.Status429TooManyRequests] = HttpStatusCodeResponses.SampleTooManyRequests429("/registrations");
             s.ResponseExamples[StatusCodes.Status500InternalServerError] = HttpStatusCodeResponses.SampleInternalServerError500("/registrations");
 
             s.Response<CreateRegistrationResponse>(StatusCodes.Status201Created, "Successfully created the registration.");
             s.Response(StatusCodes.Status401Unauthorized, "Unauthorized access.");
             s.Response<ProblemDetails>(StatusCodes.Status400BadRequest, "Invalid request parameters.", HttpContentTypes.ProblemJson);
+            s.Response<ProblemDetails>(StatusCodes.Status429TooManyRequests, "Rate limit exceeded.", HttpContentTypes.ProblemJson);
             s.Response<ProblemDetails>(StatusCodes.Status500InternalServerError, "An unexpected error occurred.", HttpContentTypes.ProblemJson);
         });
     }

--- a/source/api/Registrations/DeleteRegistration/DeleteRegistrationEndpoint.cs
+++ b/source/api/Registrations/DeleteRegistration/DeleteRegistrationEndpoint.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
+using OpenTelemetry.Trace;
 
 namespace BowlingMegabucks.TournamentManager.Api.Registrations.DeleteRegistration;
 
@@ -18,9 +19,10 @@ public sealed class DeleteRegistrationEndpoint
 
         Description(d => d
             .Produces(StatusCodes.Status204NoContent)
-            .Produces<ProblemDetails>(StatusCodes.Status400BadRequest, HttpContentTypes.ProblemJson)
+            .ProducesProblemDetails(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
-            .Produces<ProblemDetails>(StatusCodes.Status404NotFound, HttpContentTypes.ProblemJson)
+            .ProducesProblemDetails(StatusCodes.Status404NotFound)
+            .ProducesProblemDetails(StatusCodes.Status429TooManyRequests)
             .WithName("Delete Registration"));
 
         Summary(s =>
@@ -36,11 +38,13 @@ public sealed class DeleteRegistrationEndpoint
             s.ResponseExamples[StatusCodes.Status204NoContent] = new();
             s.ResponseExamples[StatusCodes.Status401Unauthorized] = HttpStatusCodeResponses.SampleUnauthorized401("/registrations/{Id}");
             s.ResponseExamples[StatusCodes.Status404NotFound] = HttpStatusCodeResponses.SampleNotFound404("/registrations/{Id}");
+            s.ResponseExamples[StatusCodes.Status429TooManyRequests] = HttpStatusCodeResponses.SampleTooManyRequests429("/registrations/{Id}");
             s.ResponseExamples[StatusCodes.Status500InternalServerError] = HttpStatusCodeResponses.SampleInternalServerError500("/registrations/{Id}");
 
             s.Response(StatusCodes.Status204NoContent, "Successfully deleted the registration.");
             s.Response(StatusCodes.Status401Unauthorized, "Unauthorized access.");
             s.Response<ProblemDetails>(StatusCodes.Status404NotFound, "Registration not found.", HttpContentTypes.ProblemJson);
+            s.Response<ProblemDetails>(StatusCodes.Status429TooManyRequests, "Rate limit exceeded.", HttpContentTypes.ProblemJson);
             s.Response<ProblemDetails>(StatusCodes.Status500InternalServerError, "An unexpected error occurred.", HttpContentTypes.ProblemJson);
         });
     }

--- a/source/api/Registrations/GetRegistration/GetRegistrationEndpoint.cs
+++ b/source/api/Registrations/GetRegistration/GetRegistrationEndpoint.cs
@@ -21,9 +21,10 @@ public sealed class GetRegistrationEndpoint
 
         Description(d => d
             .Produces<GetRegistrationResponse>(StatusCodes.Status200OK)
-            .Produces<ProblemDetails>(StatusCodes.Status400BadRequest, HttpContentTypes.ProblemJson)
+            .ProducesProblemDetails(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
-            .Produces<ProblemDetails>(StatusCodes.Status404NotFound, HttpContentTypes.ProblemJson)
+            .ProducesProblemDetails(StatusCodes.Status404NotFound)
+            .ProducesProblemDetails(StatusCodes.Status429TooManyRequests)
             .WithName(EndpointName));
 
         Summary(s =>
@@ -35,12 +36,14 @@ public sealed class GetRegistrationEndpoint
             s.ResponseExamples[StatusCodes.Status400BadRequest] = HttpStatusCodeResponses.SampleBadRequest400("/registrations/{Id}");
             s.ResponseExamples[StatusCodes.Status401Unauthorized] = HttpStatusCodeResponses.SampleUnauthorized401("/registrations/{Id}");
             s.ResponseExamples[StatusCodes.Status404NotFound] = HttpStatusCodeResponses.SampleNotFound404("/registrations/{Id}");
+            s.ResponseExamples[StatusCodes.Status429TooManyRequests] = HttpStatusCodeResponses.SampleTooManyRequests429("/registrations/{Id}");
             s.ResponseExamples[StatusCodes.Status500InternalServerError] = HttpStatusCodeResponses.SampleInternalServerError500("/registrations/{Id}");
 
             s.Response<GetRegistrationResponse>(StatusCodes.Status200OK, "Successfully retrieved the registration.");
             s.Response<ProblemDetails>(StatusCodes.Status400BadRequest, "Invalid request parameters.", HttpContentTypes.ProblemJson);
             s.Response(StatusCodes.Status401Unauthorized, "Unauthorized access.");
             s.Response<ProblemDetails>(StatusCodes.Status404NotFound, "Registration not found.", HttpContentTypes.ProblemJson);
+            s.Response<ProblemDetails>(StatusCodes.Status429TooManyRequests, "Rate limit exceeded.", HttpContentTypes.ProblemJson);
             s.Response<ProblemDetails>(StatusCodes.Status500InternalServerError, "An unexpected error occurred.", HttpContentTypes.ProblemJson);
         });
     }

--- a/source/api/Registrations/UpdateRegistration/UpdateRegistrationEndpoint.cs
+++ b/source/api/Registrations/UpdateRegistration/UpdateRegistrationEndpoint.cs
@@ -19,9 +19,10 @@ public sealed class UpdateRegistrationEndpoint
 
         Description(d => d
             .Produces(StatusCodes.Status204NoContent)
-            .Produces<ProblemDetails>(StatusCodes.Status400BadRequest, HttpContentTypes.ProblemJson)
+            .ProducesProblemDetails(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
-            .Produces<ProblemDetails>(StatusCodes.Status500InternalServerError, HttpContentTypes.ProblemJson)
+            .ProducesProblemDetails(StatusCodes.Status429TooManyRequests)
+            .ProducesProblemDetails(StatusCodes.Status500InternalServerError)
             .WithName("Update Registration"));
 
         Summary(s =>
@@ -33,11 +34,13 @@ public sealed class UpdateRegistrationEndpoint
 
             s.ResponseExamples[StatusCodes.Status400BadRequest] = HttpStatusCodeResponses.SampleBadRequest400("/registrations/{Id}");
             s.ResponseExamples[StatusCodes.Status401Unauthorized] = HttpStatusCodeResponses.SampleUnauthorized401("/registrations/{Id}");
+            s.ResponseExamples[StatusCodes.Status429TooManyRequests] = HttpStatusCodeResponses.SampleTooManyRequests429("/registrations/{Id}");
             s.ResponseExamples[StatusCodes.Status500InternalServerError] = HttpStatusCodeResponses.SampleInternalServerError500("/registrations/{Id}");
 
             s.Response<NoContent>(StatusCodes.Status204NoContent, "Successfully updated the registration.");
             s.Response<ProblemDetails>(StatusCodes.Status400BadRequest, "Invalid request parameters.", HttpContentTypes.ProblemJson);
             s.Response(StatusCodes.Status401Unauthorized, "Unauthorized access.");
+            s.Response<ProblemDetails>(StatusCodes.Status429TooManyRequests, "Rate limit exceeded.", HttpContentTypes.ProblemJson);
             s.Response<ProblemDetails>(StatusCodes.Status500InternalServerError, "An unexpected error occurred.", HttpContentTypes.ProblemJson);
         });
     }

--- a/source/api/Tournaments/GetTournament/GetTournamentEndpoint.cs
+++ b/source/api/Tournaments/GetTournament/GetTournamentEndpoint.cs
@@ -1,5 +1,4 @@
 using FastEndpoints;
-using Microsoft.AspNetCore.Http.HttpResults;
 using BowlingMegabucks.TournamentManager.Api.BogusData;
 
 namespace BowlingMegabucks.TournamentManager.Api.Tournaments.GetTournament;
@@ -21,8 +20,9 @@ public sealed class GetTournamentEndpoint
 
         Description(d => d
             .Produces<GetTournamentResponse>(StatusCodes.Status200OK, HttpContentTypes.Json)
-            .Produces<ProblemDetails>(StatusCodes.Status404NotFound, HttpContentTypes.ProblemJson)
-            .ProducesProblemDetails(StatusCodes.Status500InternalServerError, HttpContentTypes.ProblemJson)
+            .ProducesProblemDetails(StatusCodes.Status404NotFound)
+            .ProducesProblemDetails(StatusCodes.Status429TooManyRequests)
+            .ProducesProblemDetails(StatusCodes.Status500InternalServerError)
             .WithName("Get Tournament")
         );
 
@@ -38,10 +38,12 @@ public sealed class GetTournamentEndpoint
 
             s.ResponseExamples[StatusCodes.Status200OK] = new BogusGetTournamentResponse(TournamentId.New()).Generate();
             s.ResponseExamples[StatusCodes.Status404NotFound] = HttpStatusCodeResponses.SampleNotFound404("/tournaments/{Id}");
+            s.ResponseExamples[StatusCodes.Status429TooManyRequests] = HttpStatusCodeResponses.SampleTooManyRequests429("/tournaments/{Id}");
             s.ResponseExamples[StatusCodes.Status500InternalServerError] = HttpStatusCodeResponses.SampleInternalServerError500("/tournaments/{Id}");
 
             s.Response<GetTournamentResponse>(StatusCodes.Status200OK, "Returns the details of the requested tournament.");
             s.Response<ProblemDetails>(StatusCodes.Status404NotFound, "Returns a 404 Not Found if the tournament does not exist.", HttpContentTypes.ProblemJson);
+            s.Response<ProblemDetails>(StatusCodes.Status429TooManyRequests, "Returns a 429 Too Many Requests if the rate limit is exceeded.", HttpContentTypes.ProblemJson);
             s.Response<ProblemDetails>(StatusCodes.Status500InternalServerError, "Returns a generic error response in case of an unexpected error.", HttpContentTypes.ProblemJson);
         });
     }

--- a/source/api/Tournaments/GetTournaments/GetTournamentsEndpoint.cs
+++ b/source/api/Tournaments/GetTournaments/GetTournamentsEndpoint.cs
@@ -8,6 +8,17 @@ namespace BowlingMegabucks.TournamentManager.Api.Tournaments.GetTournaments;
 public sealed class GetTournamentsEndpoint
     : EndpointWithoutRequest<GetTournamentsResponse>
 {
+    private readonly ILogger<GetTournamentsEndpoint> _logger;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="logger"></param>
+    public GetTournamentsEndpoint(ILogger<GetTournamentsEndpoint> logger)
+    {
+        _logger = logger;
+    }
+
     /// <summary>
     /// 
     /// </summary>
@@ -43,6 +54,10 @@ public sealed class GetTournamentsEndpoint
     /// <returns></returns>
     public override async Task HandleAsync(CancellationToken ct)
     {
+#pragma warning disable CA1848 // Use the LoggerMessage delegates
+        _logger.LogDebug("Handling GetTournaments request");
+#pragma warning restore CA1848 // Use the LoggerMessage delegates
+
         var response = new BogusData.BogusGetTournamentsResponse().Generate();
 
         await SendOkAsync(response, ct);

--- a/source/api/Tournaments/GetTournaments/GetTournamentsEndpoint.cs
+++ b/source/api/Tournaments/GetTournaments/GetTournamentsEndpoint.cs
@@ -11,9 +11,9 @@ public sealed class GetTournamentsEndpoint
     private readonly ILogger<GetTournamentsEndpoint> _logger;
 
     /// <summary>
-    /// 
+    /// Initializes a new instance of the <see cref="GetTournamentsEndpoint"/> class.
     /// </summary>
-    /// <param name="logger"></param>
+    /// <param name="logger">The logger instance used to log diagnostic and operational information.</param>
     public GetTournamentsEndpoint(ILogger<GetTournamentsEndpoint> logger)
     {
         _logger = logger;

--- a/source/api/Tournaments/GetTournaments/GetTournamentsEndpoint.cs
+++ b/source/api/Tournaments/GetTournaments/GetTournamentsEndpoint.cs
@@ -30,7 +30,8 @@ public sealed class GetTournamentsEndpoint
 
         Description(d => d
             .Produces<GetTournamentsResponse>(StatusCodes.Status200OK, HttpContentTypes.Json)
-            .ProducesProblemDetails(StatusCodes.Status500InternalServerError, HttpContentTypes.ProblemJson)
+            .ProducesProblemDetails(StatusCodes.Status429TooManyRequests)
+            .ProducesProblemDetails(StatusCodes.Status500InternalServerError)
             .WithName("Get Tournaments")
         );
 
@@ -40,9 +41,11 @@ public sealed class GetTournamentsEndpoint
             s.Description = "This endpoint returns a list of tournaments with their details such as name, start date, end date, entry fee, and bowling center.";
 
             s.ResponseExamples[StatusCodes.Status200OK] = new BogusData.BogusGetTournamentsResponse().Generate();
+            s.ResponseExamples[StatusCodes.Status429TooManyRequests] = HttpStatusCodeResponses.SampleTooManyRequests429("/tournaments");
             s.ResponseExamples[StatusCodes.Status500InternalServerError] = HttpStatusCodeResponses.SampleInternalServerError500("/tournaments");
 
             s.Response<GetTournamentsResponse>(StatusCodes.Status200OK, "Returns a list of tournaments with their details.");
+            s.Response<ProblemDetails>(StatusCodes.Status429TooManyRequests, "Returns a 429 Too Many Requests if the rate limit is exceeded.", HttpContentTypes.ProblemJson);
             s.Response<ProblemDetails>(StatusCodes.Status500InternalServerError, "Returns a generic error response in case of an unexpected error.", HttpContentTypes.ProblemJson);
         });
     }

--- a/source/api/Tournaments/GetTournaments/TournamentSummaryDto.cs
+++ b/source/api/Tournaments/GetTournaments/TournamentSummaryDto.cs
@@ -9,7 +9,7 @@ public sealed record TournamentSummaryDto
     /// The unique identifier for the tournament.
     /// </summary>
     public required TournamentId Id { get; init; }
-    
+
     /// <summary>
     /// The name of the tournament.
     /// </summary>
@@ -34,4 +34,19 @@ public sealed record TournamentSummaryDto
     /// The bowling center where the tournament is held.
     /// </summary>
     public required string BowlingCenter { get; init; }
+
+    /// <summary>
+    /// Number of entries required to take advance an additional participant to the finals.
+    /// </summary>
+    public required decimal FinalsRatio { get; init; }
+
+    /// <summary>
+    /// The ratio of cash prizes to the total entry fees collected in the tournament.
+    /// </summary>
+    public required decimal CashRatio { get; init; }
+    
+    /// <summary>
+    /// The ratio of cash prizes for the Super Sweeper to the total entry fees collected in the tournament.
+    /// </summary>
+    public required decimal SuperSweeperCashRatio { get; init; }
 }

--- a/source/api/appsettings.Development.json
+++ b/source/api/appsettings.Development.json
@@ -4,8 +4,9 @@
   },
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information",
+      "Microsoft.EntityFrameworkCore": "Information"
     }
   },
   "Authentication": {

--- a/source/api/appsettings.Development.json
+++ b/source/api/appsettings.Development.json
@@ -11,5 +11,10 @@
   },
   "Authentication": {
     "ApiKey": "megabucks"
+  },
+
+  "RateLimiting": {
+    "PermitLimit": 3,
+    "WindowSeconds": 10
   }
 }

--- a/source/api/appsettings.json
+++ b/source/api/appsettings.json
@@ -5,8 +5,15 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+
   "AllowedHosts": "*",
+
   "Authentication": {
     "ApiKey": ""
+  },
+
+  "RateLimiting": {
+    "PermitLimit": 25,
+    "WindowSeconds": 60
   }
 }

--- a/source/api/appsettings.json
+++ b/source/api/appsettings.json
@@ -15,5 +15,9 @@
   "RateLimiting": {
     "PermitLimit": 25,
     "WindowSeconds": 60
+  },
+
+  "Performance": {
+    "DatabaseWarningThresholdMilliseconds": 250
   }
 }

--- a/source/business logic/BusinessLogicExtensions.cs
+++ b/source/business logic/BusinessLogicExtensions.cs
@@ -25,6 +25,8 @@ public static class BusinessLogicExtensions
     /// <returns></returns>
     public static IServiceCollection AddBusinessLogic(this IServiceCollection services, IConfiguration config)
     {
+        ArgumentNullException.ThrowIfNull(config);
+
         services.AddDatabase(config)
             .AddBowlersModule()
             .AddDivisionsModule()

--- a/source/business logic/Database/DataContext.cs
+++ b/source/business logic/Database/DataContext.cs
@@ -38,7 +38,8 @@ public sealed class DataContext
     private static readonly ILoggerFactory _consoleLogger = LoggerFactory.Create(builder => builder.AddConsole());
 
     /// <summary>
-    /// 
+    /// Configures the database context to use a console logger and enables sensitive data logging.
+    /// This method is only executed in the DEBUG build configuration.
     /// </summary>
     /// <param name="optionsBuilder"></param>
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/source/business logic/Database/DataContext.cs
+++ b/source/business logic/Database/DataContext.cs
@@ -11,7 +11,7 @@ namespace BowlingMegabucks.TournamentManager.Database;
 /// <summary>
 /// Represents the database context for the Tournament Manager application.
 /// </summary>
-public sealed class DataContext
+internal sealed class DataContext
     : DbContext, IDataContext
 {
 

--- a/source/business logic/Database/DataContext.cs
+++ b/source/business logic/Database/DataContext.cs
@@ -78,19 +78,26 @@ public sealed class DataContext
         modelBuilder.ApplyConfiguration(new Entities.SquadScore.Configuration());
     }
 
-    DbSet<Entities.Tournament> IDataContext.Tournaments { get; } = null!;
+    DbSet<Entities.Tournament> IDataContext.Tournaments
+        => Set<Entities.Tournament>();
 
-    DbSet<Entities.Division> IDataContext.Divisions { get; } = null!;
+    DbSet<Entities.Division> IDataContext.Divisions
+        => Set<Entities.Division>();
 
-    DbSet<Entities.TournamentSquad> IDataContext.Squads { get; } = null!;
+    DbSet<Entities.TournamentSquad> IDataContext.Squads
+        => Set<Entities.TournamentSquad>();
 
-    DbSet<Entities.SweeperSquad> IDataContext.Sweepers { get; } = null!;
+    DbSet<Entities.SweeperSquad> IDataContext.Sweepers
+        => Set<Entities.SweeperSquad>();
 
-    DbSet<Entities.Bowler> IDataContext.Bowlers { get; } = null!;
+    DbSet<Entities.Bowler> IDataContext.Bowlers
+        => Set<Entities.Bowler>();
 
-    DbSet<Entities.Registration> IDataContext.Registrations { get; } = null!;
+    DbSet<Entities.Registration> IDataContext.Registrations
+        => Set<Entities.Registration>();
 
-    DbSet<Entities.SquadScore> IDataContext.SquadScores { get; } = null!;
+    DbSet<Entities.SquadScore> IDataContext.SquadScores
+        => Set<Entities.SquadScore>();
 }
 
 internal interface IDataContext

--- a/source/business logic/Database/DataContext.cs
+++ b/source/business logic/Database/DataContext.cs
@@ -58,9 +58,10 @@ public sealed class DataContext
         => await base.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
     /// <summary>
-    /// 
+    /// Configures the entity mappings and relationships for the database context.
+    /// This method is called by the Entity Framework runtime when the model is being created.
     /// </summary>
-    /// <param name="modelBuilder"></param>
+    /// <param name="modelBuilder">The builder used to define the model for the database context.</param>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);

--- a/source/business logic/Database/DataContext.cs
+++ b/source/business logic/Database/DataContext.cs
@@ -8,14 +8,25 @@ using Microsoft.Extensions.Logging;
 
 namespace BowlingMegabucks.TournamentManager.Database;
 
-internal class DataContext 
+/// <summary>
+/// 
+/// </summary>
+public sealed class DataContext
     : DbContext, IDataContext
 {
 
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="options"></param>
     public DataContext(DbContextOptions<DataContext> options)
         : base(options)
     { }
 
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="configurationBuilder"></param>
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
         configurationBuilder.ConfigureSmartEnum();
@@ -26,8 +37,14 @@ internal class DataContext
 #if DEBUG
     private static readonly ILoggerFactory _consoleLogger = LoggerFactory.Create(builder => builder.AddConsole());
 
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="optionsBuilder"></param>
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
+
         optionsBuilder.UseLoggerFactory(_consoleLogger);
         optionsBuilder.EnableSensitiveDataLogging(true);
     }
@@ -39,8 +56,14 @@ internal class DataContext
     async Task IDataContext.SaveChangesAsync(CancellationToken cancellationToken)
         => await base.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="modelBuilder"></param>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+
         modelBuilder.ApplyConfiguration(new Entities.Tournament.Configuration());
         modelBuilder.ApplyConfiguration(new Entities.Division.Configuration());
         modelBuilder.ApplyConfiguration(new Entities.Squad.Configuration());
@@ -55,19 +78,19 @@ internal class DataContext
         modelBuilder.ApplyConfiguration(new Entities.SquadScore.Configuration());
     }
 
-    public DbSet<Entities.Tournament> Tournaments { get; set; } = null!;
+    DbSet<Entities.Tournament> IDataContext.Tournaments { get; } = null!;
 
-    public DbSet<Entities.Division> Divisions { get; set; } = null!;
+    DbSet<Entities.Division> IDataContext.Divisions { get; } = null!;
 
-    public DbSet<Entities.TournamentSquad> Squads { get; set; } = null!;
+    DbSet<Entities.TournamentSquad> IDataContext.Squads { get; } = null!;
 
-    public DbSet<Entities.SweeperSquad> Sweepers { get; set; } = null!;
+    DbSet<Entities.SweeperSquad> IDataContext.Sweepers { get; } = null!;
 
-    public DbSet<Entities.Bowler> Bowlers { get; set; } = null!;
+    DbSet<Entities.Bowler> IDataContext.Bowlers { get; } = null!;
 
-    public DbSet<Entities.Registration> Registrations { get; set; } = null!;
+    DbSet<Entities.Registration> IDataContext.Registrations { get; } = null!;
 
-    public DbSet<Entities.SquadScore> SquadScores { get; set; } = null!;
+    DbSet<Entities.SquadScore> IDataContext.SquadScores { get; } = null!;
 }
 
 internal interface IDataContext

--- a/source/business logic/Database/DataContextFactory.cs
+++ b/source/business logic/Database/DataContextFactory.cs
@@ -8,7 +8,7 @@ namespace BowlingMegabucks.TournamentManager.Database;
 /// A factory class used by Entity Framework Core at design time to create instances of <see cref="DataContext"/>.
 /// This is primarily used for migrations and other design-time operations.
 /// </summary>
-public class DataContextFactory
+internal class DataContextFactory
     : IDesignTimeDbContextFactory<DataContext>
 {
     internal static MySqlServerVersion Version

--- a/source/business logic/Database/DataContextFactory.cs
+++ b/source/business logic/Database/DataContextFactory.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace BowlingMegabucks.TournamentManager.Database;
+
+/// <summary>
+/// 
+/// </summary>
+public class DataContextFactory
+    : IDesignTimeDbContextFactory<DataContext>
+{
+    internal static MySqlServerVersion Version
+        => new(new Version(11, 4, 7));
+
+    internal static Action<MySqlDbContextOptionsBuilder> MySqlOptions
+        => mySqlOptions => mySqlOptions.EnableRetryOnFailure(3);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="args"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public DataContext CreateDbContext(string[] args)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<DataContext>();
+        var connectionString = Environment.GetEnvironmentVariable("DB_CONNECTION_STRING")
+            ?? throw new InvalidOperationException("DB_CONNECTION_STRING environment variable is not set.");
+
+        optionsBuilder.UseMySql(connectionString,
+                Version,
+                MySqlOptions);
+        return new DataContext(optionsBuilder.Options);
+    }
+}

--- a/source/business logic/Database/DatabaseExtensions.cs
+++ b/source/business logic/Database/DatabaseExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using BowlingMegabucks.TournamentManager.Database.Interceptors;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -12,9 +13,11 @@ public static class DatabaseExtensions
 {
     internal static IServiceCollection AddDatabase(this IServiceCollection services, IConfiguration config)
     {
-        services.AddDbContext<DataContext>(options =>
-            options.UseMySql(config.GetConnectionString("Default") ?? throw new InvalidOperationException("Cannot get connection string Default"),
-            DataContextFactory.Version, DataContextFactory.MySqlOptions));
+        services.AddScoped<PerformanceInterceptor>();
+        services.AddDbContext<DataContext>((sp, options) => options
+            .UseMySql(config.GetConnectionString("Default") ?? throw new InvalidOperationException("Cannot get connection string Default"),
+                DataContextFactory.Version, DataContextFactory.MySqlOptions)
+            .AddInterceptors(sp.GetRequiredService<PerformanceInterceptor>()));
 
         services.AddTransient<IDataContext, DataContext>();
 

--- a/source/business logic/Database/DatabaseExtensions.cs
+++ b/source/business logic/Database/DatabaseExtensions.cs
@@ -13,6 +13,8 @@ public static class DatabaseExtensions
 {
     internal static IServiceCollection AddDatabase(this IServiceCollection services, IConfiguration config)
     {
+        services.Configure<DatabasePerformanceOptions>(config.GetSection("Performance"));
+        
         services.AddScoped<PerformanceInterceptor>();
         services.AddDbContext<DataContext>((sp, options) => options
             .UseMySql(config.GetConnectionString("Default") ?? throw new InvalidOperationException("Cannot get connection string Default"),

--- a/source/business logic/Database/DatabaseExtensions.cs
+++ b/source/business logic/Database/DatabaseExtensions.cs
@@ -14,7 +14,7 @@ public static class DatabaseExtensions
     {
         services.AddDbContext<DataContext>(options =>
             options.UseMySql(config.GetConnectionString("Default") ?? throw new InvalidOperationException("Cannot get connection string Default"),
-            new MySqlServerVersion(new Version(11, 4, 7)), mySqlOptions => mySqlOptions.EnableRetryOnFailure(3)));
+            DataContextFactory.Version, DataContextFactory.MySqlOptions));
 
         services.AddTransient<IDataContext, DataContext>();
 

--- a/source/business logic/Database/Interceptors/DatabasePerformanceOptions.cs
+++ b/source/business logic/Database/Interceptors/DatabasePerformanceOptions.cs
@@ -1,0 +1,6 @@
+namespace BowlingMegabucks.TournamentManager.Database.Interceptors;
+
+internal sealed class DatabasePerformanceOptions
+{
+    public int DatabaseWarningThresholdMilliseconds { get; set; } = 250;
+}

--- a/source/business logic/Database/Interceptors/PerformanceInterceptor.cs
+++ b/source/business logic/Database/Interceptors/PerformanceInterceptor.cs
@@ -16,31 +16,27 @@ internal class PerformanceInterceptor : DbCommandInterceptor
         _warningThresholdMilliseconds = options.Value.DatabaseWarningThresholdMilliseconds;
     }
 
-    public override DbDataReader ReaderExecuted(DbCommand command, CommandExecutedEventData eventData, DbDataReader result)
+    private void LogCommandExecution(string commandText, double durationMilliseconds)
     {
-        if (eventData.Duration.TotalMilliseconds > _warningThresholdMilliseconds)
+        if (durationMilliseconds > _warningThresholdMilliseconds)
         {
-            PerformanceLogger.LogCommandExecutionWarning(_logger, command.CommandText, eventData.Duration.TotalMilliseconds);
+            PerformanceLogger.LogCommandExecutionWarning(_logger, commandText, durationMilliseconds);
         }
         else
         {
-            PerformanceLogger.LogCommandExecution(_logger, command.CommandText, eventData.Duration.TotalMilliseconds);
+            PerformanceLogger.LogCommandExecution(_logger, commandText, durationMilliseconds);
         }
+    }
 
+    public override DbDataReader ReaderExecuted(DbCommand command, CommandExecutedEventData eventData, DbDataReader result)
+    {
+        LogCommandExecution(command.CommandText, eventData.Duration.TotalMilliseconds);
         return base.ReaderExecuted(command, eventData, result);
     }
 
     public override ValueTask<DbDataReader> ReaderExecutedAsync(DbCommand command, CommandExecutedEventData eventData, DbDataReader result, CancellationToken cancellationToken = default)
     { 
-        if (eventData.Duration.TotalMilliseconds > _warningThresholdMilliseconds)
-        {
-            PerformanceLogger.LogCommandExecutionWarning(_logger, command.CommandText, eventData.Duration.TotalMilliseconds);
-        }
-        else
-        {
-            PerformanceLogger.LogCommandExecution(_logger, command.CommandText, eventData.Duration.TotalMilliseconds);
-        }
-
+        LogCommandExecution(command.CommandText, eventData.Duration.TotalMilliseconds);
         return base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
     }
 }

--- a/source/business logic/Database/Interceptors/PerformanceInterceptor.cs
+++ b/source/business logic/Database/Interceptors/PerformanceInterceptor.cs
@@ -1,0 +1,54 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace BowlingMegabucks.TournamentManager.Database.Interceptors;
+
+internal class PerformanceInterceptor
+    : DbCommandInterceptor
+{
+    private const int _warningThresholdMilliseconds = 250; // Threshold for logging long queries
+    private readonly ILogger<PerformanceInterceptor> _logger;
+
+    public PerformanceInterceptor(ILogger<PerformanceInterceptor> logger)
+    {
+        _logger = logger;
+    }
+
+    public override DbDataReader ReaderExecuted(DbCommand command, CommandExecutedEventData eventData, DbDataReader result)
+    {
+        if (eventData.Duration.TotalMilliseconds > _warningThresholdMilliseconds)
+        {
+            PerformanceLogger.LogCommandExecutionWarning(_logger, command.CommandText, eventData.Duration.TotalMilliseconds);
+        }
+        else
+        {
+            PerformanceLogger.LogCommandExecution(_logger, command.CommandText, eventData.Duration.TotalMilliseconds);
+        }
+
+        return base.ReaderExecuted(command, eventData, result);
+    }
+
+    public override ValueTask<DbDataReader> ReaderExecutedAsync(DbCommand command, CommandExecutedEventData eventData, DbDataReader result, CancellationToken cancellationToken = default)
+    { 
+        if (eventData.Duration.TotalMilliseconds > _warningThresholdMilliseconds)
+        {
+            PerformanceLogger.LogCommandExecutionWarning(_logger, command.CommandText, eventData.Duration.TotalMilliseconds);
+        }
+        else
+        {
+            PerformanceLogger.LogCommandExecution(_logger, command.CommandText, eventData.Duration.TotalMilliseconds);
+        }
+
+        return base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
+    }
+}
+
+internal static partial class PerformanceLogger
+{
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Executing command: {CommandText} -- Duration: {ElapsedMilliseconds} ms", EventName = "CommandExecution")]
+    public static partial void LogCommandExecution(ILogger<PerformanceInterceptor> logger, string commandText, double elapsedMilliseconds);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Long Query: {Query} -- Duration: {ElapsedMilliseconds} ms", EventName = "CommandExecutionWarning")]
+    public static partial void LogCommandExecutionWarning(ILogger<PerformanceInterceptor> logger, string query, double elapsedMilliseconds);
+}

--- a/source/business logic/Database/Interceptors/PerformanceInterceptor.cs
+++ b/source/business logic/Database/Interceptors/PerformanceInterceptor.cs
@@ -1,18 +1,19 @@
 using System.Data.Common;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace BowlingMegabucks.TournamentManager.Database.Interceptors;
 
-internal class PerformanceInterceptor
-    : DbCommandInterceptor
+internal class PerformanceInterceptor : DbCommandInterceptor
 {
-    private const int _warningThresholdMilliseconds = 250; // Threshold for logging long queries
+    private readonly int _warningThresholdMilliseconds;
     private readonly ILogger<PerformanceInterceptor> _logger;
 
-    public PerformanceInterceptor(ILogger<PerformanceInterceptor> logger)
+    public PerformanceInterceptor(ILogger<PerformanceInterceptor> logger, IOptions<DatabasePerformanceOptions> options)
     {
         _logger = logger;
+        _warningThresholdMilliseconds = options.Value.DatabaseWarningThresholdMilliseconds;
     }
 
     public override DbDataReader ReaderExecuted(DbCommand command, CommandExecutedEventData eventData, DbDataReader result)

--- a/source/infrastructure/main.tf
+++ b/source/infrastructure/main.tf
@@ -155,26 +155,26 @@ resource "azurerm_linux_web_app" "api" {
 
 resource "azurerm_application_insights_web_test" "api_health_check" {
   name                    = "api-health-check"
-  location                = azurerm_application_insights.appinsights.location
-  resource_group_name     = azurerm_resource_group.rg.name
-  application_insights_id = azurerm_application_insights.appinsights.id
+  location                = azurerm_application_insights.application_insights.location
+  resource_group_name     = azurerm_resource_group.resource_group.name
+  application_insights_id = azurerm_application_insights.application_insights.id
   kind                    = "ping"
   frequency               = 300 # seconds
   timeout                 = 30
   enabled                 = true
 
   geo_locations = [
-  "us-west-azr",
-  "us-southcentral-azr",
-  "us-northcentral-azr",
-  "us-east-azr",
-  "us-central-azr"
-]
+    "us-west-azr",
+    "us-southcentral-azr",
+    "us-northcentral-azr",
+    "us-east-azr",
+    "us-central-azr"
+  ]
 
   configuration = <<WEBTEST
-<WebTest Name="api-health-check" Id="12345678-1234-1234-1234-123456789abc" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="30" WorkItemIds="" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+<WebTest Name="api-health-check" Id="e2b1c7a2-4d3e-4b8a-9c1f-2a7e5b6d8f9c" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="30" WorkItemIds="" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
   <Items>
-    <Request Method="GET" Guid="abcdefab-1234-5678-9abc-def012345678" Version="1.1" Url="https://${azurerm_linux_web_app.api.default_hostname}${azurerm_linux_web_app.api.site_config[0].health_check_path}" ThinkTime="0" Timeout="30" ParseDependentRequests="True" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
+    <Request Method="GET" Guid="a1f3b5c7-8d9e-4a2b-9c3d-5e6f7a8b9c0d" Version="1.1" Url="https://${azurerm_linux_web_app.api.default_hostname}${azurerm_linux_web_app.api.site_config[0].health_check_path}" ThinkTime="0" Timeout="30" ParseDependentRequests="True" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
   </Items>
 </WebTest>
 WEBTEST

--- a/source/infrastructure/main.tf
+++ b/source/infrastructure/main.tf
@@ -134,7 +134,8 @@ resource "azurerm_linux_web_app" "api" {
       dotnet_version = "9.0"
     }
 
-    health_check_path = "/health"
+    health_check_path                 = "/health"
+    health_check_eviction_time_in_min = 2
   }
 
   app_settings = {

--- a/source/infrastructure/stage.tfvars
+++ b/source/infrastructure/stage.tfvars
@@ -8,7 +8,7 @@ app_service_plan_sku_name = "B2"
 log_analytics_workspace_sku            = "PerGB2018"
 log_analytics_workspace_retention_days = 30
 
-asp_net_core_environment = "Staging"
+asp_net_core_environment   = "Staging"
 api_megabucks_url_redirect = "api.staging.bowlingmegabucks.com"
 
 key_vault_purge_protection_enabled = false

--- a/source/main/appsettings.json
+++ b/source/main/appsettings.json
@@ -2,5 +2,9 @@
   "KeyVaultConfig": {
     "TenantId": "13cbb532-ee62-4767-b9b8-28c93b026e48",
     "ClientId": "48bcdd5d-1897-4b7d-b337-dc0d583dee54"
+  },
+
+  "Performance": {
+    "DatabaseWarningThresholdMilliseconds": 250
   }
 }


### PR DESCRIPTION
This pull request introduces several enhancements, including rate limiting middleware, improved health checks, and updates to endpoint configurations. The changes focus on adding new features, improving observability, and refining existing functionality.

### New Features
* Added `RateLimitingMiddleware` to enforce per-IP rate limiting using a token bucket algorithm, with configurable options for permit limits and window duration (`source/api/Middleware/RateLimitingMiddleware.cs`, `source/api/RateLimitingOptions.cs`, `source/api/Program.cs`) [[1]](diffhunk://#diff-a88972e054c19f254711c0de3dcdda06e459db529b1ede457154aad114671aeaR1-R71) [[2]](diffhunk://#diff-35e64078047ef68e40dbad5dc61793e5a28c2fa9d1d891710ed213b84dabc043R1-R7) [[3]](diffhunk://#diff-af008d11361ae389a583d99b37d91b2abb0e1a0be2968539e122de0c9ebac32aL123-R164).
* Implemented a new `RequestContextLoggingMiddleware` to log correlation IDs for improved traceability (`source/api/Middleware/RequestContextLoggingMiddleware.cs`, `source/api/Program.cs`) [[1]](diffhunk://#diff-e6ca6f21295bd382c4e5b3f40223b1988971141a368be69aa4e395309b1eb4d5R1-R35) [[2]](diffhunk://#diff-af008d11361ae389a583d99b37d91b2abb0e1a0be2968539e122de0c9ebac32aR180-R183).

### Observability and Health Checks
* Added health check for MySQL database connectivity and a custom JSON response writer for health check results (`source/api/Program.cs`) [[1]](diffhunk://#diff-af008d11361ae389a583d99b37d91b2abb0e1a0be2968539e122de0c9ebac32aR18-R38) [[2]](diffhunk://#diff-af008d11361ae389a583d99b37d91b2abb0e1a0be2968539e122de0c9ebac32aL123-R164).
* Enhanced OpenTelemetry instrumentation by adding meters for ASP.NET Core hosting and Kestrel server metrics (`source/api/Program.cs`).

### Endpoint Enhancements
* Updated all registration-related endpoints to include support for `429 Too Many Requests` responses, aligning with the new rate limiting feature (`source/api/Registrations/CreateRegistration/CreateRegistrationEndpoint.cs`, `source/api/Registrations/DeleteRegistration/DeleteRegistrationEndpoint.cs`, `source/api/Registrations/GetRegistration/GetRegistrationEndpoint.cs`, `source/api/Registrations/UpdateRegistration/UpdateRegistrationEndpoint.cs`) [[1]](diffhunk://#diff-f983cdd2fa1072bf78d0611f55ddc0f5673f43af283c017e72fe763b8d84890aL22-R25) [[2]](diffhunk://#diff-f983cdd2fa1072bf78d0611f55ddc0f5673f43af283c017e72fe763b8d84890aR40-R46) [[3]](diffhunk://#diff-fc9d82c8c2e3abb27132744a728f10e103d0e9e4c240e3081216c1ee4f8cd48eL21-R25) [[4]](diffhunk://#diff-fc9d82c8c2e3abb27132744a728f10e103d0e9e4c240e3081216c1ee4f8cd48eR41-R47) [[5]](diffhunk://#diff-3b76d20c2afd42f52fdcc8cd125dd115c424d5b18e608417b1a43c4a70eb07bbL24-R27) [[6]](diffhunk://#diff-3b76d20c2afd42f52fdcc8cd125dd115c424d5b18e608417b1a43c4a70eb07bbR39-R46) [[7]](diffhunk://#diff-c00edcccf053f01198eed9956c59e731349d3b1ee710e2bd3f8aff884852c8ddL22-R25) [[8]](diffhunk://#diff-c00edcccf053f01198eed9956c59e731349d3b1ee710e2bd3f8aff884852c8ddR37-R43).

### Dependency Updates
* Added a new package dependency for `AspNetCore.HealthChecks.MySql` to support database health checks (`source/Directory.Packages.props`, `source/api/BowlingMegabucks.TournamentManager.Api.csproj`) [[1]](diffhunk://#diff-93dd950fdb499f49a16299ef23ad9944cac0c05d0321dea6e7601c153b752833R10) [[2]](diffhunk://#diff-6e84de523ce03da07c1945654a8a4ce55dd558250185e27678b6484ce3f64093R14).

### Miscellaneous
* Added new rules for generating tournament DTOs in `BogusTournamentSummaryDto.cs` to include `FinalsRatio`, `CashRatio`, and `SuperSweeperCashRatio` fields (`source/api/BogusData/BogusTournamentSummaryDto.cs`).
* Introduced a `429 Too Many Requests` sample response in `HttpStatusCodeResponses.cs` for consistency across endpoints (`source/api/HttpStatusCodeResponses.cs`).