### PR TITLE
 Update Registration (PATCH)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,5 +58,8 @@
             "password": "password",
             "group": "Bowling Megabucks"
         }
+    ],
+    "cSpell.words": [
+        "USBC"
     ]
 }

--- a/source/Directory.Packages.props
+++ b/source/Directory.Packages.props
@@ -56,12 +56,12 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.7" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.12.0-beta.2" />
-    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-rc.1.efcore.9.0.0" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageVersion Include="QuestPDF" Version="2025.7.0" />
     <PackageVersion Include="ReportGenerator" Version="5.4.12" />
     <PackageVersion Include="ReportViewerCore.WinForms" Version="15.1.17" />
     <PackageVersion Include="Respawn" Version="6.2.1" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.6.9" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.7.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Enrichers.AspNetCore" Version="1.0.0" />
     <PackageVersion Include="Serilog.Enrichers.ClientInfo" Version="2.3.0" />

--- a/source/api/BogusData/BogusUpdateRegistrationRequest.cs
+++ b/source/api/BogusData/BogusUpdateRegistrationRequest.cs
@@ -9,6 +9,6 @@ internal sealed class BogusUpdateRegistrationRequest
     public BogusUpdateRegistrationRequest()
     {
         RuleFor(request => request.Registration, _ => new BogusUpdateRegistrationInput().Generate());
-        RuleFor(request => request.Id, (_, request) => request.Registration.RegistrationId);
+        RuleFor(request => request.RegistrationId, (_, request) => request.Registration.RegistrationId);
     }
 }

--- a/source/api/HttpStatusCodeResponses.cs
+++ b/source/api/HttpStatusCodeResponses.cs
@@ -87,12 +87,28 @@ internal static class HttpStatusCodeResponses
 
         var problemDetails = new Microsoft.AspNetCore.Mvc.ProblemDetails
         {
-            //TODO: map error metadata to extensions
             Detail = detail,
             Status = statusCode,
             Extensions =
                 {
-                    ["errors"] = errors.Select(e => new { e.Code, e.Description, Value=e.Metadata?["PropertyValue"] }).ToList(),
+                    ["errors"] = errors.Select(e => 
+                    {
+                        var errorObj = new Dictionary<string, object?>
+                        {
+                            ["code"] = e.Code,
+                            ["description"] = e.Description
+                        };
+                        
+                        if (e.Metadata != null)
+                        {
+                            foreach (var kvp in e.Metadata)
+                            {
+                                errorObj[kvp.Key] = kvp.Value;
+                            }
+                        }
+                        
+                        return errorObj;
+                    }).ToList(),
                     ["traceId"] = traceId
                 }
         };

--- a/source/api/HttpStatusCodeResponses.cs
+++ b/source/api/HttpStatusCodeResponses.cs
@@ -87,6 +87,7 @@ internal static class HttpStatusCodeResponses
 
         var problemDetails = new Microsoft.AspNetCore.Mvc.ProblemDetails
         {
+            //TODO: map error metadata to extensions
             Detail = detail,
             Status = statusCode,
             Extensions =

--- a/source/api/Registrations/CreateRegistration/CreateRegistrationRequest.cs
+++ b/source/api/Registrations/CreateRegistration/CreateRegistrationRequest.cs
@@ -1,3 +1,5 @@
+using FastEndpoints;
+
 namespace BowlingMegabucks.TournamentManager.Api.Registrations.CreateRegistration;
 
 /// <summary>

--- a/source/api/Registrations/CreateRegistration/CreateRegistrationValidator.cs
+++ b/source/api/Registrations/CreateRegistration/CreateRegistrationValidator.cs
@@ -52,12 +52,5 @@ internal sealed class CreateRegistrationValidator
             .NotEmpty()
             .WithMessage("At least one squad must be entered.")
             .WithErrorCode("Registration.SquadsRequired");
-
-        RuleFor(request => request.Registration.SuperSweeper)
-            .Must((request, _) => request.Registration.Sweepers.Any())
-            .When(request => request.Registration.SuperSweeper)
-            .WithMessage("Sweepers must be entered if Super Sweeper is selected.")
-            .WithErrorCode("Registration.SweeperRequiredForSuperSweeper");
-
     }
 }

--- a/source/api/Registrations/UpdateRegistration/UpdateRegistrationInput.cs
+++ b/source/api/Registrations/UpdateRegistration/UpdateRegistrationInput.cs
@@ -19,6 +19,12 @@ public sealed record UpdateRegistrationInput
     public DivisionId? DivisionId { get; init; }
 
     /// <summary>
+    /// The bowlers average.  This is required for certain divisions
+    /// </summary>
+    /// <value></value>
+    public int? Average { get; init; }  
+
+    /// <summary>
     /// Squad IDs associated with the registration.  This is a complete set of the participant's squads.
     /// If the participant is not in any squads, this will be empty.  If there is no change, this should be null.
     /// </summary>

--- a/source/api/Registrations/UpdateRegistration/UpdateRegistrationInput.cs
+++ b/source/api/Registrations/UpdateRegistration/UpdateRegistrationInput.cs
@@ -12,6 +12,13 @@ public sealed record UpdateRegistrationInput
     public required RegistrationId RegistrationId { get; init; }
 
     /// <summary>
+    /// The ID of the division to update.
+    /// If not specified, the division will not be changed.
+    /// </summary>
+    /// <value></value>
+    public DivisionId? DivisionId { get; init; }
+
+    /// <summary>
     /// Squad IDs associated with the registration.  This is a complete set of the participant's squads.
     /// If the participant is not in any squads, this will be empty.  If there is no change, this should be null.
     /// </summary>

--- a/source/api/Registrations/UpdateRegistration/UpdateRegistrationRequest.cs
+++ b/source/api/Registrations/UpdateRegistration/UpdateRegistrationRequest.cs
@@ -8,7 +8,15 @@ namespace BowlingMegabucks.TournamentManager.Api.Registrations.UpdateRegistratio
 public sealed record UpdateRegistrationRequest
 {
     /// <summary>
+    /// The unique identifier of the registration.
+    /// </summary>
+    /// <value></value>
+    [BindFrom("Id")]
+    public required RegistrationId RegistrationId { get; init; }
+
+    /// <summary>
     /// The registration to update.
     /// </summary>
+    [FromBody]
     public required UpdateRegistrationInput Registration { get; init; }
 }

--- a/source/api/Registrations/UpdateRegistration/UpdateRegistrationRequest.cs
+++ b/source/api/Registrations/UpdateRegistration/UpdateRegistrationRequest.cs
@@ -8,11 +8,6 @@ namespace BowlingMegabucks.TournamentManager.Api.Registrations.UpdateRegistratio
 public sealed record UpdateRegistrationRequest
 {
     /// <summary>
-    /// The ID of the registration to update.  This comes from the route parameter.
-    /// </summary>
-    public required RegistrationId Id { get; init; }
-
-    /// <summary>
     /// The registration to update.
     /// </summary>
     public required UpdateRegistrationInput Registration { get; init; }

--- a/source/api/Registrations/UpdateRegistration/UpdateRegistrationRequest.cs
+++ b/source/api/Registrations/UpdateRegistration/UpdateRegistrationRequest.cs
@@ -11,12 +11,11 @@ public sealed record UpdateRegistrationRequest
     /// The unique identifier of the registration.
     /// </summary>
     /// <value></value>
-    [BindFrom("Id")]
+    [RouteParam]
     public required RegistrationId RegistrationId { get; init; }
 
     /// <summary>
     /// The registration to update.
     /// </summary>
-    [FromBody]
     public required UpdateRegistrationInput Registration { get; init; }
 }

--- a/source/api/Registrations/UpdateRegistration/UpdateRegistrationRequestValidator.cs
+++ b/source/api/Registrations/UpdateRegistration/UpdateRegistrationRequestValidator.cs
@@ -8,7 +8,7 @@ internal sealed class UpdateRegistrationRequestValidator
 {
     public UpdateRegistrationRequestValidator()
     {
-        RuleFor(request => request.Id)
+        RuleFor(request => request.RegistrationId)
             .NotNull()
             .WithMessage("Registration ID is required.")
             .WithErrorCode("Registration.IdRequired");
@@ -18,8 +18,8 @@ internal sealed class UpdateRegistrationRequestValidator
             .WithMessage("Registration details are required.")
             .WithErrorCode("Registration.Required");
 
-        RuleFor(request => request.Id)
-            .Must((request, id) => request.Id == request.Registration.RegistrationId)
+        RuleFor(request => request.RegistrationId)
+            .Must((request, id) => request.RegistrationId == request.Registration.RegistrationId)
             .WithMessage("Registration ID in the request does not match the ID in the registration details.")
             .WithErrorCode("Registration.IdMismatch");
     }

--- a/source/business logic/Database/Entities/SquadEntity.cs
+++ b/source/business logic/Database/Entities/SquadEntity.cs
@@ -46,9 +46,9 @@ internal abstract class Squad
             builder.Property(squad => squad.TournamentId).HasConversion<TournamentId.EfCoreValueConverter>();
 
             builder.ToTable("Squads")
-                      .HasDiscriminator<int>("SquadType")
-                      .HasValue<TournamentSquad>(0)
-                      .HasValue<SweeperSquad>(1);
+                      .HasDiscriminator<SquadType>("SquadType")
+                      .HasValue<TournamentSquad>(SquadType.Squad)
+                      .HasValue<SweeperSquad>(SquadType.Sweeper);
         }
     }
 }

--- a/source/business logic/Database/Entities/SquadType.cs
+++ b/source/business logic/Database/Entities/SquadType.cs
@@ -1,0 +1,8 @@
+namespace BowlingMegabucks.TournamentManager.Database.Entities;
+
+internal enum SquadType
+{
+    Squad = 0,
+
+    Sweeper = 1
+}

--- a/source/business logic/Registrations/CreateRegistration/CreateRegistrationCommandHandlerTelemetryDecorator.cs
+++ b/source/business logic/Registrations/CreateRegistration/CreateRegistrationCommandHandlerTelemetryDecorator.cs
@@ -65,7 +65,7 @@ internal static partial class CreateRegistrationLogMessages
     [LoggerMessage(LogLevel.Information, "Creating registration for bowler with UsbcId {UsbcId} in tournament {TournamentId}")]
     public static partial void CreatingRegistration(this ILogger logger, string usbcId, TournamentId tournamentId);
 
-    [LoggerMessage(LogLevel.Error, "Error creating registration: {@Errors}")]
+    [LoggerMessage(LogLevel.Information, "Error creating registration: {@Errors}")]
     public static partial void ErrorCreatingRegistration(this ILogger logger, IEnumerable<Error> errors);
 
     [LoggerMessage(LogLevel.Error, "Exception creating registration")]

--- a/source/business logic/Registrations/DeleteRegistration/DeleteRegistrationCommandHandlerTelemetryDecorator.cs
+++ b/source/business logic/Registrations/DeleteRegistration/DeleteRegistrationCommandHandlerTelemetryDecorator.cs
@@ -66,7 +66,7 @@ internal static partial class DeleteRegistrationLogMessages
     [LoggerMessage(LogLevel.Information, "Deleting registration with Id {RegistrationId}")]
     public static partial void DeletingRegistration(this ILogger logger, RegistrationId registrationId);
 
-    [LoggerMessage(LogLevel.Error, "Error deleting registration: {@Errors}")]
+    [LoggerMessage(LogLevel.Information, "Error deleting registration: {@Errors}")]
     public static partial void ErrorDeletingRegistration(this ILogger logger, IEnumerable<Error> errors);
 
     [LoggerMessage(LogLevel.Error, "Exception deleting registration")]

--- a/source/business logic/Registrations/GetRegistrationById/GetRegistrationByIdQueryHandlerTelemetryDecorator.cs
+++ b/source/business logic/Registrations/GetRegistrationById/GetRegistrationByIdQueryHandlerTelemetryDecorator.cs
@@ -64,8 +64,7 @@ internal static partial class GetRegistrationByIdLogMessages
     [LoggerMessage(Level = LogLevel.Debug, Message = "Executing business logic for retrieving registration {Id}.", EventName = "RetrieveRegistrationById")]
     public static partial void RetrievingRegistration(this ILogger<GetRegistrationByIdQueryHandlerTelemetryDecorator> logger, RegistrationId id);
 
-    // need to bring in serilog
-    [LoggerMessage(Level = LogLevel.Error, Message = "Error retrieving Registration: {@Errors}", EventName = "ErrorRetrievingRegistration")]
+    [LoggerMessage(Level = LogLevel.Information, Message = "Error retrieving Registration: {@Errors}", EventName = "ErrorRetrievingRegistration")]
     public static partial void ErrorRetrievingRegistration(this ILogger<GetRegistrationByIdQueryHandlerTelemetryDecorator> logger, IEnumerable<Error> errors);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Error retrieving registration", EventName = "ExceptionRetrievingRegistration")]

--- a/source/business logic/Registrations/PaymentEntityMapper.cs
+++ b/source/business logic/Registrations/PaymentEntityMapper.cs
@@ -1,0 +1,20 @@
+namespace BowlingMegabucks.TournamentManager.Registrations;
+
+internal sealed class PaymentEntityMapper
+    : IPaymentEntityMapper
+{
+    public Database.Entities.Payment Execute(Models.Payment payment)
+        => new()
+        {
+            Id = payment.Id,
+            ConfirmationCode = payment.ConfirmationCode,
+            CreatedAtUtc = payment.CreatedAtUtc,
+            RegistrationId = payment.RegistrationId,
+            Amount = payment.Amount
+        };
+}
+
+internal interface IPaymentEntityMapper
+{
+    Database.Entities.Payment Execute(Models.Payment payment);
+}

--- a/source/business logic/Registrations/RegistrationEntityMapper.cs
+++ b/source/business logic/Registrations/RegistrationEntityMapper.cs
@@ -4,19 +4,16 @@ namespace BowlingMegabucks.TournamentManager.Registrations;
 internal class EntityMapper : IEntityMapper
 {
     private readonly Bowlers.IEntityMapper _bowlerMapper;
-
-    public EntityMapper()
-    {
-        _bowlerMapper = new Bowlers.EntityMapper();
-    }
+    private readonly IPaymentEntityMapper _paymentMapper;
 
     /// <summary>
-    /// Unit Test Constructor
+    /// 
     /// </summary>
     /// <param name="bowlerMapper"></param>
-    internal EntityMapper(Bowlers.IEntityMapper bowlerMapper)
+    public EntityMapper(Bowlers.IEntityMapper bowlerMapper, IPaymentEntityMapper paymentMapper)
     {
         _bowlerMapper = bowlerMapper;
+        _paymentMapper = paymentMapper;
     }
 
     public Database.Entities.Registration Execute(Models.Registration registration)
@@ -33,18 +30,8 @@ internal class EntityMapper : IEntityMapper
                     RegistrationId = registration.Id,
                     SquadId = id
                 })],
-            Payments = [.. registration.Payments.Select(Execute)],
+            Payments = [.. registration.Payments.Select(_paymentMapper.Execute)],
             SuperSweeper = registration.SuperSweeper
-        };
-        
-    private Database.Entities.Payment Execute(Models.Payment payment)
-        => new()
-        {
-            Id = payment.Id,
-            ConfirmationCode = payment.ConfirmationCode,
-            CreatedAtUtc = payment.CreatedAtUtc,
-            RegistrationId = payment.RegistrationId,
-            Amount = payment.Amount
         };
 }
 

--- a/source/business logic/Registrations/RegistrationExtensions.cs
+++ b/source/business logic/Registrations/RegistrationExtensions.cs
@@ -16,6 +16,7 @@ internal static class RegistrationExtensions
     {
         services.AddTransient<IRepository, Repository>();
         services.AddSingleton<IEntityMapper, EntityMapper>();
+        services.AddSingleton<IPaymentEntityMapper, PaymentEntityMapper>();
 
         services.AddSingleton<IValidator<Models.Registration>, Validator>();
         services.AddTransient<Add.IBusinessLogic, Add.BusinessLogic>();

--- a/source/business logic/Registrations/RegistrationExtensions.cs
+++ b/source/business logic/Registrations/RegistrationExtensions.cs
@@ -42,6 +42,13 @@ internal static class RegistrationExtensions
         services.AddTransient<Retrieve.IBusinessLogic, Retrieve.BusinessLogic>();
         services.AddTransient<Retrieve.IDataLayer, Retrieve.DataLayer>();
 
+        services.AddSingleton<IValidator<UpdateRegistration.UpdateRegistrationRecord>, UpdateRegistration.Validator>();
+        services.AddTransient<UpdateRegistration.UpdateRegistrationCommandHandler>();
+        services.AddTransient<ICommandHandler<UpdateRegistration.UpdateRegistrationCommand, Updated>>(provider =>
+            new UpdateRegistration.UpdateRegistrationCommandHandlerTelemetryDecorator(
+                provider.GetRequiredService<UpdateRegistration.UpdateRegistrationCommandHandler>(),
+                provider.GetRequiredService<ILogger<UpdateRegistration.UpdateRegistrationCommandHandlerTelemetryDecorator>>()));
+
         services.AddSingleton<IValidator<Update.UpdateRegistrationModel>, Update.Validator>();
         services.AddTransient<Update.IBusinessLogic, Update.BusinessLogic>();
         services.AddTransient<Update.IDataLayer, Update.DataLayer>();

--- a/source/business logic/Registrations/RegistrationRepository.cs
+++ b/source/business logic/Registrations/RegistrationRepository.cs
@@ -58,7 +58,6 @@ internal class Repository : IRepository
             .Include(registration => registration.Bowler)
             .Include(registration => registration.Division).ThenInclude(division => division.Tournament)
             .Include(registration => registration.Payments)
-            .AsNoTracking()
             .FirstOrDefaultAsync(registration => registration.Id == id, cancellationToken).ConfigureAwait(false);
 
     async Task IRepository.DeleteAsync(BowlerId bowlerId, SquadId squadId, CancellationToken cancellationToken)

--- a/source/business logic/Registrations/RegistrationRepository.cs
+++ b/source/business logic/Registrations/RegistrationRepository.cs
@@ -118,6 +118,13 @@ internal class Repository : IRepository
     async Task IRepository.UpdateAsync(RegistrationId id, int? average, CancellationToken cancellationToken)
         => await _dataContext.Registrations.Where(registration => registration.Id == id)
             .ExecuteUpdateAsync(setters => setters.SetProperty(registration => registration.Average, average), cancellationToken).ConfigureAwait(false);
+
+    async Task IRepository.UpdateAsync(Database.Entities.Registration registration, CancellationToken cancellationToken)
+    {
+        _dataContext.Registrations.Update(registration);
+        
+        await _dataContext.SaveChangesAsync(cancellationToken);
+    }
 }
 
 internal interface IRepository
@@ -139,4 +146,6 @@ internal interface IRepository
     Task UpdateAsync(RegistrationId id, DivisionId divisionId, Gender? gender, int? average, string? usbcId, DateOnly? dateOfBirth, CancellationToken cancellationToken);
 
     Task UpdateAsync(RegistrationId id, int? average, CancellationToken cancellationToken);
+
+    Task UpdateAsync(Database.Entities.Registration registration, CancellationToken cancellationToken);
 }

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommand.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommand.cs
@@ -25,6 +25,12 @@ public sealed record UpdateRegistrationCommand
     public DivisionId? DivisionId { get; init; }
 
     /// <summary>
+    /// The bowlers average.  This is required for certain divisions
+    /// </summary>
+    /// <value></value>
+    public int? Average { get; init; }
+
+    /// <summary>
     /// Squad IDs associated with the registration.  This is a complete set of the participant's squads.
     /// If the participant is not in any squads, this will be empty.  If there is no change, this should be null.
     /// </summary>

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommand.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommand.cs
@@ -1,37 +1,47 @@
+using BowlingMegabucks.TournamentManager.Abstractions.Messaging;
+using BowlingMegabucks.TournamentManager.Models;
+using ErrorOr;
 
-namespace BowlingMegabucks.TournamentManager.Api.Registrations.UpdateRegistration;
+namespace BowlingMegabucks.TournamentManager.Registrations.UpdateRegistration;
 
 /// <summary>
-/// Input for updating a registration.
+/// Command to update a registration.
 /// </summary>
-public sealed record UpdateRegistrationInput
+/// <value></value>
+public sealed record UpdateRegistrationCommand
+    : ICommand<Updated>
 {
     /// <summary>
-    /// The ID of the registration to update.
+    /// The unique identifier of the registration to update.
     /// </summary>
-    public required RegistrationId RegistrationId { get; init; }
+    /// <value></value>
+    public required RegistrationId Id { get; init; }
 
     /// <summary>
     /// Squad IDs associated with the registration.  This is a complete set of the participant's squads.
     /// If the participant is not in any squads, this will be empty.  If there is no change, this should be null.
     /// </summary>
+    /// <value></value>
     public IEnumerable<SquadId>? SquadIds { get; init; }
 
     /// <summary>
     /// IDs of sweepers associated with the registration.  This is a complete set of the participant's sweepers.
-    /// If the participant is not in a sweeper, this will be empty.  If there is no change, this should be null.
+    /// If the participant is not a sweeper, this will be empty.  If there is no change, this should be null.
     /// </summary>
+    /// <value></value>
     public IEnumerable<SquadId>? SweeperIds { get; init; }
 
     /// <summary>
     /// Indicates if the participant is in the super sweeper.
     /// If there is no change, this should be null.
     /// </summary>
+    /// <value></value>
     public bool? SuperSweeper { get; init; }
 
     /// <summary>
     /// The payment confirmation for the registration if a new payment has been made or a refund has been issued.
     /// If there is no new charge, this should be null.
     /// </summary>
-    public PaymentInput? Payment { get; init; }
+    /// <value></value>
+    public Payment? Payment { get; init; }
 }

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommand.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommand.cs
@@ -18,6 +18,13 @@ public sealed record UpdateRegistrationCommand
     public required RegistrationId Id { get; init; }
 
     /// <summary>
+    /// The ID of the division to update.
+    /// If not specified, the division will not be changed.
+    /// </summary>
+    /// <value></value>
+    public DivisionId? DivisionId { get; init; }
+
+    /// <summary>
     /// Squad IDs associated with the registration.  This is a complete set of the participant's squads.
     /// If the participant is not in any squads, this will be empty.  If there is no change, this should be null.
     /// </summary>

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
@@ -2,7 +2,6 @@ using BowlingMegabucks.TournamentManager.Abstractions.Messaging;
 using BowlingMegabucks.TournamentManager.Database.Entities;
 using ErrorOr;
 using FluentValidation;
-using TournamentManager.BusinessLogic.Registrations.UpdateRegistration;
 
 namespace BowlingMegabucks.TournamentManager.Registrations.UpdateRegistration;
 

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
@@ -7,10 +7,14 @@ internal sealed class UpdateRegistrationCommandHandler
     : ICommandHandler<UpdateRegistrationCommand, Updated>
 {
     private readonly IRepository _registrationRepository;
+    private readonly Scores.IRepository _scoresRepository;
+    private readonly Tournaments.IRepository _tournamentRepository;
 
-    public UpdateRegistrationCommandHandler(IRepository registrationRepository)
+    public UpdateRegistrationCommandHandler(IRepository registrationRepository, Scores.IRepository scoresRepository, Tournaments.IRepository tournamentRepository)
     {
         _registrationRepository = registrationRepository;
+        _scoresRepository = scoresRepository;
+        _tournamentRepository = tournamentRepository;
     }
 
     public async Task<ErrorOr<Updated>> HandleAsync(UpdateRegistrationCommand command, CancellationToken cancellationToken)
@@ -24,13 +28,39 @@ internal sealed class UpdateRegistrationCommandHandler
                 description: $"Registration with ID {command.Id} not found.");
         }
 
+        var tournament = new Lazy<Task<Database.Entities.Tournament?>>(async () => await _tournamentRepository.RetrieveAsync(existingRegistration.Division.TournamentId, cancellationToken));
+
         if (command.DivisionId is not null)
         {
+            existingRegistration.Average = command.Average ?? existingRegistration.Average;
+            // validate division id is valid for tournament
             // validate bowler can participate in the division (meets the criteria of division and that bowler hasn't bowled)
+            // look at the create registration validator for the division rules
+        }
+
+        if (command.Payment is not null)
+        {
+            command.Payment.CreatedAtUtc = DateTime.UtcNow;
+
+            //map payment model to entity (exists in registration entity mapper) and add to registration
         }
 
         if (command.SquadIds is not null || command.SweeperIds is not null)
         {
+            var squadIds = (command.SquadIds ?? []).Union(command.SweeperIds ?? []).ToList();
+            var invalidSquadIds = squadIds.Except(existingRegistration.Squads.Select(s => s.SquadId)).ToList();
+
+            if (invalidSquadIds.Count > 0)
+            {
+                return Error.Validation(
+                    code: "Registration.InvalidSquadIds",
+                    description: "Invalid squad/sweeper IDs",
+                    metadata: new Dictionary<string, object>
+                    {
+                        { "InvalidSquadIds", string.Join(", ", invalidSquadIds) }
+                    });
+            }
+
             //validate the squad ids and sweeper ids are a part of the tournament (get tournament and check squads/sweepers)
             //if scores have been bowled already in a squad, make sure that squad (sweeper) is still in the list
         }
@@ -39,13 +69,6 @@ internal sealed class UpdateRegistrationCommandHandler
         {
             // validate that the bowler is registered (or will be registered) for all sweepers (if SuperSweeper is true)
             // make sure no sweepers scores have been bowled
-        }
-
-        if (command.Payment is not null)
-        {
-            command.Payment.CreatedAtUtc = DateTime.UtcNow;
-
-            //map payment model to entity (exists in registration entity mapper) and add to registration
         }
 
         await _registrationRepository.UpdateAsync(existingRegistration, cancellationToken);

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
@@ -1,0 +1,55 @@
+using BowlingMegabucks.TournamentManager.Abstractions.Messaging;
+using ErrorOr;
+
+namespace BowlingMegabucks.TournamentManager.Registrations.UpdateRegistration;
+
+internal sealed class UpdateRegistrationCommandHandler
+    : ICommandHandler<UpdateRegistrationCommand, Updated>
+{
+    private readonly IRepository _registrationRepository;
+
+    public UpdateRegistrationCommandHandler(IRepository registrationRepository)
+    {
+        _registrationRepository = registrationRepository;
+    }
+
+    public async Task<ErrorOr<Updated>> HandleAsync(UpdateRegistrationCommand command, CancellationToken cancellationToken)
+    {
+        var existingRegistration = await _registrationRepository.RetrieveAsync(command.Id, cancellationToken);
+
+        if (existingRegistration is null)
+        {
+            return Error.NotFound(
+                code: "Registration.NotFound",
+                description: $"Registration with ID {command.Id} not found.");
+        }
+
+        if (command.DivisionId is not null)
+        {
+            // validate bowler can participate in the division (meets the criteria of division and that bowler hasn't bowled)
+        }
+
+        if (command.SquadIds is not null || command.SweeperIds is not null)
+        {
+            //validate the squad ids and sweeper ids are a part of the tournament (get tournament and check squads/sweepers)
+            //if scores have been bowled already in a squad, make sure that squad (sweeper) is still in the list
+        }
+
+        if (command.SuperSweeper.HasValue)
+        {
+            // validate that the bowler is registered (or will be registered) for all sweepers (if SuperSweeper is true)
+            // make sure no sweepers scores have been bowled
+        }
+
+        if (command.Payment is not null)
+        {
+            command.Payment.CreatedAtUtc = DateTime.UtcNow;
+
+            //map payment model to entity (exists in registration entity mapper) and add to registration
+        }
+
+        await _registrationRepository.UpdateAsync(existingRegistration, cancellationToken);
+
+        return Result.Updated;
+    }
+}

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
@@ -196,12 +196,11 @@ internal sealed class UpdateRegistrationCommandHandler
                 });
         }
 
-        var tournamentSquadIds = tournament!.Squads.Select(squad => squad.Id);
-
-        return tournament!.Squads
-            .Where(s => tournamentSquadIds.Contains(s.Id))
-            .Select(s => new SquadRegistration { SquadId = s.Id, RegistrationId = existingRegistration.Id })
+        var squadRegistrations = squadIds
+            .Select(s => new SquadRegistration { SquadId = s, RegistrationId = existingRegistration.Id })
             .ToList();
+
+        return squadRegistrations;
     }
     
     private async Task<ErrorOr<IEnumerable<SquadRegistration>>> UpdateSweepers(IReadOnlyCollection<SquadId> sweeperIds, Tournament tournament, Registration existingRegistration, CancellationToken cancellationToken)
@@ -252,11 +251,10 @@ internal sealed class UpdateRegistrationCommandHandler
                 });
         }
 
-        var tournamentSweeperIds = tournament!.Sweepers.Select(sweeper => sweeper.Id);
-
-        return tournament!.Sweepers
-            .Where(s => tournamentSweeperIds.Contains(s.Id))
-            .Select(s => new SquadRegistration { SquadId = s.Id, RegistrationId = existingRegistration.Id })
+        var sweeperRegistrations = sweeperIds
+            .Select(s => new SquadRegistration { SquadId = s, RegistrationId = existingRegistration.Id })
             .ToList();
+
+        return sweeperRegistrations;
     }
 }

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
@@ -125,7 +125,7 @@ internal sealed class UpdateRegistrationCommandHandler
                 existingRegistration.Bowler,
                 tournament!,
                 tournament!.Divisions.Single(division => division.Id == command.DivisionId.Value),
-                command.Average);
+                existingRegistration.Average);
 
             var validatorResults = await _registrationValidator.ValidateAsync(updateRecord, cancellationToken);
 

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
@@ -164,15 +164,16 @@ internal sealed class UpdateRegistrationCommandHandler
         }
 
         var addedSquadIds = squadIds.Except(existingRegistration.Squads.Select(s => s.SquadId));
+        var completedSquadIds = addedSquadIds.Where(squadId => tournament.Squads.Where(s => s.Complete).Select(s => s.Id).Contains(squadId)).ToList();
 
-        if (addedSquadIds.Any(squadId => existingRegistration.Squads.Where(s => s.Squad.Complete).Select(s => s.SquadId).Contains(squadId)))
+        if (completedSquadIds.Count > 0)
         {
             return Error.Validation(
                 code: "Registration.InvalidSquadIds",
                 description: "Cannot add squad(s) that are already complete.",
                 metadata: new Dictionary<string, object>
                 {
-                    { "InvalidSquadIds", string.Join(", ", addedSquadIds) }
+                    { "InvalidSquadIds", string.Join(", ", completedSquadIds) }
                 });
         }
 
@@ -204,7 +205,7 @@ internal sealed class UpdateRegistrationCommandHandler
     }
     
     private async Task<ErrorOr<IEnumerable<SquadRegistration>>> UpdateSweepers(IReadOnlyCollection<SquadId> sweeperIds, Tournament tournament, Registration existingRegistration, CancellationToken cancellationToken)
-    {
+    {       
         var invalidSweeperIds = sweeperIds.Except(tournament!.Sweepers.Select(s => s.Id)).ToList(); // command sweeper ids not a part of tournament
 
         if (invalidSweeperIds.Count > 0)
@@ -219,15 +220,15 @@ internal sealed class UpdateRegistrationCommandHandler
         }
 
         var addedSquadIds = sweeperIds.Except(existingRegistration.Squads.Select(s => s.SquadId));
-
-        if (addedSquadIds.Any(squadId => existingRegistration.Squads.Where(s => s.Squad.Complete).Select(s => s.SquadId).Contains(squadId)))
+        var addedCompletedSquadIds = addedSquadIds.Where(squadId => tournament.Sweepers.Where(s => s.Complete).Select(s => s.Id).Contains(squadId)).ToList();
+        if (addedCompletedSquadIds.Count > 0)
         {
             return Error.Validation(
                 code: "Registration.InvalidSweeperIds",
                 description: "Cannot add sweeper(s) that are already complete.",
                 metadata: new Dictionary<string, object>
                 {
-                    { "InvalidSweeperIds", string.Join(", ", addedSquadIds) }
+                    { "InvalidSweeperIds", string.Join(", ", addedCompletedSquadIds) }
                 });
         }
 

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandler.cs
@@ -140,6 +140,7 @@ internal sealed class UpdateRegistrationCommandHandler
         if (command.Payment is not null)
         {
             command.Payment.CreatedAtUtc = DateTime.UtcNow;
+            command.Payment.RegistrationId = existingRegistration.Id;
 
             existingRegistration.Payments.Add(_paymentMapper.Execute(command.Payment));
         }

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandlerTelemetryDecorator.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationCommandHandlerTelemetryDecorator.cs
@@ -1,0 +1,78 @@
+using System.Diagnostics;
+using BowlingMegabucks.TournamentManager.Abstractions.Messaging;
+using ErrorOr;
+using Microsoft.Extensions.Logging;
+
+namespace BowlingMegabucks.TournamentManager.Registrations.UpdateRegistration;
+
+internal sealed class UpdateRegistrationCommandHandlerTelemetryDecorator
+    : ICommandHandler<UpdateRegistrationCommand, Updated>
+{
+    private readonly ICommandHandler<UpdateRegistrationCommand, Updated> _innerHandler;
+    private readonly ILogger<UpdateRegistrationCommandHandlerTelemetryDecorator> _logger;
+
+    public UpdateRegistrationCommandHandlerTelemetryDecorator(ICommandHandler<UpdateRegistrationCommand, Updated> innerHandler, ILogger<UpdateRegistrationCommandHandlerTelemetryDecorator> logger)
+    {
+        _innerHandler = innerHandler;
+        _logger = logger;
+    }
+
+    public async Task<ErrorOr<Updated>> HandleAsync(UpdateRegistrationCommand command, CancellationToken cancellationToken)
+    {
+        using var activity = RegistrationsTelemetry._activity.StartActivity("Update Registration", ActivityKind.Internal);
+
+        _logger.UpdatingRegistration(command.Id);
+
+        try
+        {
+            activity?.SetTag("registration.id", command.Id.Value);
+
+            var result = await _innerHandler.HandleAsync(command, cancellationToken);
+
+            if (result.IsError)
+            {
+                _logger.ErrorUpdatingRegistration(result.Errors);
+
+                activity?.SetStatus(ActivityStatusCode.Error);
+                activity?.SetTag("error", true);
+                activity?.SetTag("error.message", string.Join(", ", result.Errors.Select(e => e.Description)));
+
+                return result;
+            }
+
+            _logger.RegistrationUpdated(command.Id);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.ErrorUpdatingRegistration(ex);
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+            activity?.SetTag("exception", ex.ToString());
+
+            return Error.Failure("UpdateRegistrationCommandHandler.Exception", ex.Message);
+        }
+        finally
+        {
+            _logger.ExecutedUpdateRegistration(command.Id);
+        }
+    }
+}
+
+internal static partial class UpdateRegistrationLogMessages
+{
+    [LoggerMessage(LogLevel.Information, "Updating registration {RegistrationId}")]
+    public static partial void UpdatingRegistration(this ILogger logger, RegistrationId registrationId);
+
+    [LoggerMessage(LogLevel.Information, "Error updating registration: {@Errors}")]
+    public static partial void ErrorUpdatingRegistration(this ILogger logger, IEnumerable<Error> errors);
+
+    [LoggerMessage(LogLevel.Error, "Exception updating registration")]
+    public static partial void ErrorUpdatingRegistration(this ILogger logger, Exception ex);
+
+    [LoggerMessage(LogLevel.Information, "Registration updated successfully: {RegistrationId}")]
+    public static partial void RegistrationUpdated(this ILogger logger, RegistrationId registrationId);
+
+    [LoggerMessage(LogLevel.Information, "Executed update registration for {RegistrationId}")]
+    public static partial void ExecutedUpdateRegistration(this ILogger logger, RegistrationId registrationId);
+}

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationValidator.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationValidator.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
 using BowlingMegabucks.TournamentManager.Database.Entities;
 
-namespace TournamentManager.BusinessLogic.Registrations.UpdateRegistration;
+namespace BowlingMegabucks.TournamentManager.Registrations.UpdateRegistration;
 
 internal sealed class Validator
     : AbstractValidator<UpdateRegistrationRecord>

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationValidator.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationValidator.cs
@@ -1,0 +1,60 @@
+using FluentValidation;
+using BowlingMegabucks.TournamentManager.Database.Entities;
+
+namespace TournamentManager.BusinessLogic.Registrations.UpdateRegistration;
+
+internal sealed class Validator
+    : AbstractValidator<UpdateRegistrationRecord>
+{
+    public Validator()
+    {
+        RuleFor(record => record.Average).NotNull().When(record => record.Division.MinimumAverage.HasValue || record.Division.MaximumAverage.HasValue).WithMessage("Average is required for selected division");
+        RuleFor(record => record.Average).GreaterThanOrEqualTo(record => record.Division.MinimumAverage!.Value).When(record => record.Division.MinimumAverage.HasValue).WithMessage("Minimum average requirement for division not met");
+        RuleFor(record => record.Average).LessThanOrEqualTo(record => record.Division.MaximumAverage!.Value).When(record => record.Division.MaximumAverage.HasValue).WithMessage("Maximum average requirement for division not met");
+
+        RuleFor(record => record.Bowler.DateOfBirth).Must(dateOfBirth => dateOfBirth.HasValue)
+            .When(record => (record.Division.MinimumAge.HasValue || record.Division.MaximumAge.HasValue) && record.Division.Gender is null)
+            .WithMessage("Date of birth required for selected division");
+        RuleFor(record => record.Bowler.DateOfBirth).Must((record, dateOfBirth) => record.Bowler.AgeOn(record.Tournament.Start) >= record.Division.MinimumAge!.Value)
+            .When(record => record.Division.MinimumAge.HasValue)
+            .When(record => (record.Division.Gender is not null && record.Division.Gender != record.Bowler.Gender) || record.Division.Gender is null)
+            .WithMessage("Bowler too young for selected division");
+        RuleFor(record => record.Bowler.DateOfBirth).Must((record, dateOfBirth) => record.Bowler.AgeOn(record.Tournament.Start) <= record.Division.MaximumAge!.Value)
+            .When(record => record.Division.MaximumAge.HasValue)
+            .When(record => (record.Division.Gender is not null && record.Division.Gender != record.Bowler.Gender) || record.Division.Gender is null)
+            .WithMessage("Bowler too old for selected division");
+
+        RuleFor(registration => registration.Bowler.USBCId).NotEmpty().When(registration => registration.Division.HandicapPercentage.HasValue).WithMessage("USBC Id is required for Handicap Divisions");
+
+        RuleFor(registration => registration.Bowler.Gender).Must(gender => gender is not null)
+            .When(registration => registration.Division.Gender is not null)
+            .When(registration => !(registration.Division.MinimumAge.HasValue || registration.Division.MaximumAge.HasValue))
+            .WithMessage("Gender is required for selected division");
+        RuleFor(registration => registration.Bowler.Gender).Must((registration, gender) => registration.Division.Gender!.Value == gender)
+            .When(registration => registration.Division.Gender is not null)
+            .When(registration => !(registration.Division.MinimumAge.HasValue || registration.Division.MaximumAge.HasValue))
+            .WithMessage("Invalid gender for selected division");
+    }
+}
+
+internal sealed record UpdateRegistrationRecord(Bowler Bowler, Tournament Tournament, Division Division, int? Average);
+
+internal static class UpdateRegistrationRecordExtensions
+{
+    public static int? AgeOn(this Bowler bowler, DateOnly date)
+    {
+        if (!bowler.DateOfBirth.HasValue)
+        {
+            return null;
+        }
+
+        var age = date.Year - bowler.DateOfBirth.Value.Year;
+
+        if (bowler.DateOfBirth > date.AddYears(-age))
+        {
+            age--;
+        }
+
+        return age;
+    }
+}

--- a/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationValidator.cs
+++ b/source/business logic/Registrations/UpdateRegistration/UpdateRegistrationValidator.cs
@@ -8,9 +8,18 @@ internal sealed class Validator
 {
     public Validator()
     {
-        RuleFor(record => record.Average).NotNull().When(record => record.Division.MinimumAverage.HasValue || record.Division.MaximumAverage.HasValue).WithMessage("Average is required for selected division");
-        RuleFor(record => record.Average).GreaterThanOrEqualTo(record => record.Division.MinimumAverage!.Value).When(record => record.Division.MinimumAverage.HasValue).WithMessage("Minimum average requirement for division not met");
-        RuleFor(record => record.Average).LessThanOrEqualTo(record => record.Division.MaximumAverage!.Value).When(record => record.Division.MaximumAverage.HasValue).WithMessage("Maximum average requirement for division not met");
+        RuleFor(record => record.Average)
+            .NotNull()
+                .When(record => record.Division.MinimumAverage.HasValue || record.Division.MaximumAverage.HasValue)
+                .WithMessage("Average is required for selected division");
+        RuleFor(record => record.Average)
+            .GreaterThanOrEqualTo(record => record.Division.MinimumAverage!.Value)
+                .When(record => record.Division.MinimumAverage.HasValue)
+                .WithMessage("Minimum average requirement for division not met");
+        RuleFor(record => record.Average)
+            .LessThanOrEqualTo(record => record.Division.MaximumAverage!.Value)
+                .When(record => record.Division.MaximumAverage.HasValue)
+                .WithMessage("Maximum average requirement for division not met");
 
         RuleFor(record => record.Bowler.DateOfBirth).Must(dateOfBirth => dateOfBirth.HasValue)
             .When(record => (record.Division.MinimumAge.HasValue || record.Division.MaximumAge.HasValue) && record.Division.Gender is null)
@@ -24,16 +33,21 @@ internal sealed class Validator
             .When(record => (record.Division.Gender is not null && record.Division.Gender != record.Bowler.Gender) || record.Division.Gender is null)
             .WithMessage("Bowler too old for selected division");
 
-        RuleFor(registration => registration.Bowler.USBCId).NotEmpty().When(registration => registration.Division.HandicapPercentage.HasValue).WithMessage("USBC Id is required for Handicap Divisions");
+        RuleFor(registration => registration.Bowler.USBCId)
+            .NotEmpty()
+                .When(registration => registration.Division.HandicapPercentage.HasValue)
+                .WithMessage("USBC Id is required for Handicap Divisions");
 
-        RuleFor(registration => registration.Bowler.Gender).Must(gender => gender is not null)
-            .When(registration => registration.Division.Gender is not null)
-            .When(registration => !(registration.Division.MinimumAge.HasValue || registration.Division.MaximumAge.HasValue))
-            .WithMessage("Gender is required for selected division");
-        RuleFor(registration => registration.Bowler.Gender).Must((registration, gender) => registration.Division.Gender!.Value == gender)
-            .When(registration => registration.Division.Gender is not null)
-            .When(registration => !(registration.Division.MinimumAge.HasValue || registration.Division.MaximumAge.HasValue))
-            .WithMessage("Invalid gender for selected division");
+        RuleFor(registration => registration.Bowler.Gender)
+            .Must(gender => gender is not null)
+                .When(registration => registration.Division.Gender is not null)
+                .When(registration => !(registration.Division.MinimumAge.HasValue || registration.Division.MaximumAge.HasValue))
+                .WithMessage("Gender is required for selected division");
+        RuleFor(registration => registration.Bowler.Gender)
+            .Must((registration, gender) => registration.Division.Gender!.Value == gender)
+                .When(registration => registration.Division.Gender is not null)
+                .When(registration => !(registration.Division.MinimumAge.HasValue || registration.Division.MaximumAge.HasValue))
+                .WithMessage("Invalid gender for selected division");
     }
 }
 

--- a/source/business logic/Scores/ScoresRepository.cs
+++ b/source/business logic/Scores/ScoresRepository.cs
@@ -53,6 +53,11 @@ internal class Repository : IRepository
             .Include(squadScore => squadScore.Squad)
         .Where(squadScore => squadIds.Contains(squadScore.SquadId));
 
+    public async Task<IReadOnlyCollection<Database.Entities.SquadScore>> BowlerScoresForSquads(BowlerId bowlerId, IEnumerable<SquadId> squadIds, CancellationToken cancellationToken)
+        => await _dataContext.SquadScores.AsNoTracking()
+            .Where(score => score.BowlerId == bowlerId && squadIds.Contains(score.SquadId))
+            .ToListAsync(cancellationToken);
+
     public async Task<bool> DoesBowlerHaveAnyScoresForTournamentAsync(RegistrationId registrationId, TournamentId tournamentId, CancellationToken cancellationToken)
     {
         var tournamentSquadIds = _dataContext.Squads.AsNoTracking()
@@ -84,4 +89,6 @@ internal interface IRepository
     IQueryable<Database.Entities.SquadScore> Retrieve(params SquadId[] squadIds);
 
     Task<bool> DoesBowlerHaveAnyScoresForTournamentAsync(RegistrationId registrationId, TournamentId tournamentId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyCollection<Database.Entities.SquadScore>> BowlerScoresForSquads(BowlerId bowlerId, IEnumerable<SquadId> squadIds, CancellationToken cancellationToken);
 }

--- a/source/business logic/Tournaments/GetTournamentById/GetTournamentByIdQueryHandlerTelemetryDecorator.cs
+++ b/source/business logic/Tournaments/GetTournamentById/GetTournamentByIdQueryHandlerTelemetryDecorator.cs
@@ -64,8 +64,7 @@ internal static partial class GetTournamentByIdLogMessages
     [LoggerMessage(Level = LogLevel.Debug, Message = "Executing business logic for retrieving tournament {Id}.", EventName = "RetrieveTournamentById")]
     public static partial void RetrievingTournament(this ILogger<GetTournamentByIdQueryHandlerTelemetryDecorator> logger, TournamentId id);
 
-    // need to bring in serilog
-    [LoggerMessage(Level = LogLevel.Error, Message = "Error retrieving tournament: {@Errors}", EventName = "ErrorRetrievingTournament")]
+    [LoggerMessage(Level = LogLevel.Information, Message = "Error retrieving tournament: {@Errors}", EventName = "ErrorRetrievingTournament")]
     public static partial void ErrorRetrievingTournament(this ILogger<GetTournamentByIdQueryHandlerTelemetryDecorator> logger, IEnumerable<Error> errors);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Error retrieving tournament", EventName = "ExceptionRetrievingTournament")]

--- a/source/business logic/Tournaments/GetTournaments/GetTournamentsQueryHandlerTelemetryDecorator.cs
+++ b/source/business logic/Tournaments/GetTournaments/GetTournamentsQueryHandlerTelemetryDecorator.cs
@@ -68,8 +68,7 @@ internal static partial class GetTournamentsLogMessages
     [LoggerMessage(Level = LogLevel.Trace, Message = "Executing business logic for retrieving tournaments.", EventName = "RetrieveTournaments")]
     public static partial void RetrievingTournaments(this ILogger<GetTournamentsQueryHandlerTelemetryDecorator> logger);
 
-    // need to bring in serilog
-    [LoggerMessage(Level = LogLevel.Error, Message = "Error retrieving tournaments: {@Errors}", EventName = "ErrorRetrievingTournaments")]
+    [LoggerMessage(Level = LogLevel.Information, Message = "Error retrieving tournaments: {@Errors}", EventName = "ErrorRetrievingTournaments")]
     public static partial void ErrorRetrievingTournaments(this ILogger<GetTournamentsQueryHandlerTelemetryDecorator> logger, IEnumerable<Error> errors);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Error retrieving tournaments", EventName = "ExceptionRetrievingTournaments")]

--- a/source/tests/BowlingMegabucks.TournamentManager.IntegrationTests/Registrations/RegistrationEntityFactory.cs
+++ b/source/tests/BowlingMegabucks.TournamentManager.IntegrationTests/Registrations/RegistrationEntityFactory.cs
@@ -8,6 +8,30 @@ namespace BowlingMegabucks.TournamentManager.IntegrationTests.Registrations;
 
 internal static class RegistrationEntityFactory
 {
+    public static Registration Create(
+        RegistrationId? id = null,
+        Division? division = null,
+        Bowler? bowler = null,
+        IEnumerable<SquadId>? squadIds = null,
+        IEnumerable<SquadId>? sweeperIds = null,
+        bool? superSweeper = null,
+        int? average = null,
+        Payment? payment = null
+    ) => new()
+    {
+        Id = id ?? RegistrationId.New(),
+        DivisionId = division?.Id ?? DivisionId.New(),
+        BowlerId = bowler?.Id ?? BowlerId.New(),
+        Squads = squadIds?.Union(sweeperIds ?? []).Select(squadId => new SquadRegistration
+        {
+            SquadId = squadId,
+            RegistrationId = id ?? RegistrationId.New()
+        }).ToList() ?? [],
+        SuperSweeper = superSweeper ?? false,
+        Average = average,
+        Payments = [payment ?? PaymentEntityFactory.Bogus()]
+    };
+    
     public static Registration Bogus(Bowler bowler, Division division, IEnumerable<Squad>? squads = null)
         => new RegistrationEntityFaker(bowler, division, squads).Generate();
 }

--- a/source/tests/BowlingMegabucks.TournamentManager.IntegrationTests/Registrations/UpdateRegistrationTests.cs
+++ b/source/tests/BowlingMegabucks.TournamentManager.IntegrationTests/Registrations/UpdateRegistrationTests.cs
@@ -1,0 +1,491 @@
+using System.Collections;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BowlingMegabucks.TournamentManager.Api.Registrations.UpdateRegistration;
+using BowlingMegabucks.TournamentManager.Database.Entities;
+using BowlingMegabucks.TournamentManager.IntegrationTests.Bowlers;
+using BowlingMegabucks.TournamentManager.IntegrationTests.Divisions;
+using BowlingMegabucks.TournamentManager.IntegrationTests.Infrastructure;
+using BowlingMegabucks.TournamentManager.IntegrationTests.Squads;
+using BowlingMegabucks.TournamentManager.IntegrationTests.Sweepers;
+using BowlingMegabucks.TournamentManager.IntegrationTests.Tournaments;
+using Microsoft.EntityFrameworkCore;
+
+namespace BowlingMegabucks.TournamentManager.IntegrationTests.Registrations;
+
+public sealed class UpdateRegistrationTests
+    : IntegrationTestFixture
+{
+    public UpdateRegistrationTests(TournamentManagerWebAppFactory factory)
+        : base(factory)
+    { }
+
+    [Fact]
+    public async Task UpdateRegistration_ShouldReturn400_WhenRegistrationIdInRouteDoesNotMatchRegistrationIdInBody()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+
+        var tournament = TournamentEntityFactory.Bogus();
+        var division = DivisionEntityFactory.Create(tournament.Id);
+        var squads = SquadEntityFactory.Bogus(3, tournament.Id);
+        var sweepers = SweeperEntityFactory.Bogus(2, tournament.Id);
+        var bowler = BowlerEntityFactory.Bogus();
+
+        var registration = RegistrationEntityFactory.Create(
+            bowler: bowler,
+            division: division,
+            squadIds: squads.Select(s => s.Id),
+            sweeperIds: sweepers.Select(s => s.Id));
+
+        _dbContext.Tournaments.Add(tournament);
+        _dbContext.Divisions.Add(division);
+        _dbContext.Squads.AddRange(squads);
+        _dbContext.Sweepers.AddRange(sweepers);
+        _dbContext.Bowlers.Add(bowler);
+        _dbContext.Registrations.Add(registration);
+
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var registrationInput = new UpdateRegistrationInput
+        {
+            RegistrationId = RegistrationId.New(),
+            DivisionId = division.Id,
+            SuperSweeper = false,
+            Average = 200,
+        };
+
+        var updateRegistrationRequest = new UpdateRegistrationRequest
+        {
+            RegistrationId = RegistrationId.New(),
+            Registration = registrationInput
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Patch, $"v1/registrations/{updateRegistrationRequest.RegistrationId}")
+        {
+            Content = JsonContent.Create(updateRegistrationRequest)
+        };
+
+        // Act
+        var response = await CreateAuthenticatedClient().SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problemDetails = await response.Content.ReadFromJsonAsync<FastEndpoints.ProblemDetails>(TestContext.Current.CancellationToken);
+
+        problemDetails.Should().NotBeNull();
+        problemDetails!.Title.Should().Be("Bad Request");
+        problemDetails.Errors.First().Reason.Should().Be("Registration ID in the request does not match the ID in the registration details.");
+    }
+
+    [Fact]
+    public async Task UpdateRegistration_ShouldReturn400_WhenTryingToAddASquadThatHasAlreadyCompleted()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+
+        var tournament = TournamentEntityFactory.Bogus();
+        var division = DivisionEntityFactory.Create(tournament.Id);
+        var squads = SquadEntityFactory.Bogus(3, tournament.Id).ToList();
+        var sweepers = SweeperEntityFactory.Bogus(2, tournament.Id);
+        var bowler = BowlerEntityFactory.Bogus();
+
+        var registration = RegistrationEntityFactory.Create(
+            bowler: bowler,
+            division: division,
+            squadIds: [squads.Select(s => s.Id).First()],
+            sweeperIds: sweepers.Select(s => s.Id));
+
+        squads.Last().Complete = true;
+
+        _dbContext.Tournaments.Add(tournament);
+        _dbContext.Divisions.Add(division);
+        _dbContext.Squads.AddRange(squads);
+        _dbContext.Sweepers.AddRange(sweepers);
+        _dbContext.Bowlers.Add(bowler);
+        _dbContext.Registrations.Add(registration);
+
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var registrationInput = new UpdateRegistrationInput
+        {
+            RegistrationId = registration.Id,
+            SquadIds = [squads[0].Id, squads[2].Id]
+        };
+
+        var updateRegistrationRequest = new UpdateRegistrationRequest
+        {
+            RegistrationId = registrationInput.RegistrationId,
+            Registration = registrationInput
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Patch, $"v1/registrations/{updateRegistrationRequest.RegistrationId}")
+        {
+            Content = JsonContent.Create(updateRegistrationRequest)
+        };
+
+        // Act
+        var response = await CreateAuthenticatedClient().SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problemDetails = await response.Content.ReadFromJsonAsync<Microsoft.AspNetCore.Mvc.ProblemDetails>(TestContext.Current.CancellationToken);
+
+        problemDetails.Should().NotBeNull();
+        problemDetails!.Title.Should().Be("Bad Request");
+        problemDetails.Detail.Should().Be("Error updating registration.");
+        problemDetails.Extensions.Should().ContainKey("errors");
+
+        var errorsJson = (JsonElement)problemDetails.Extensions["errors"]!;
+        errorsJson.ValueKind.Should().Be(JsonValueKind.Array);
+
+        var errors = errorsJson.EnumerateArray().ToList();
+        errors.Should().ContainSingle();
+
+        var firstError = errors.First();
+        firstError.GetProperty("code").GetString().Should().Be("Registration.InvalidSquadIds");
+        firstError.GetProperty("description").GetString().Should().Be("Cannot add squad(s) that are already complete.");
+        firstError.GetProperty("InvalidSquadIds").GetString().Should().Be(squads[2].Id.ToString());
+
+        var verifyRegistration = await _dbContext.Registrations
+            .Include(registration => registration.Squads)
+            .AsNoTrackingWithIdentityResolution()
+            .SingleAsync(registration => registration.Id == updateRegistrationRequest.RegistrationId, TestContext.Current.CancellationToken);
+
+        verifyRegistration.Squads.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task UpdateRegistration_ShouldReturn400_WhenTryingToRemoveASweeperThatBowlerHasBowledIn()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+
+        var tournament = TournamentEntityFactory.Bogus();
+        var division = DivisionEntityFactory.Create(tournament.Id);
+        var squads = SquadEntityFactory.Bogus(3, tournament.Id).ToList();
+        var sweepers = SweeperEntityFactory.Bogus(2, tournament.Id);
+        var bowler = BowlerEntityFactory.Bogus();
+
+        var registration = RegistrationEntityFactory.Create(
+            bowler: bowler,
+            division: division,
+            squadIds: [squads.Select(s => s.Id).First()],
+            sweeperIds: sweepers.Select(s => s.Id));
+
+        var squadScore = new SquadScore
+        {
+            SquadId = squads[0].Id,
+            BowlerId = bowler.Id,
+            Game = 1,
+            Score = 200
+        };
+
+        _dbContext.Tournaments.Add(tournament);
+        _dbContext.Divisions.Add(division);
+        _dbContext.Squads.AddRange(squads);
+        _dbContext.Sweepers.AddRange(sweepers);
+        _dbContext.Bowlers.Add(bowler);
+        _dbContext.Registrations.Add(registration);
+        _dbContext.SquadScores.Add(squadScore);
+
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var registrationInput = new UpdateRegistrationInput
+        {
+            RegistrationId = registration.Id,
+            SquadIds = [squads[1].Id, squads[2].Id]
+        };
+
+        var updateRegistrationRequest = new UpdateRegistrationRequest
+        {
+            RegistrationId = registrationInput.RegistrationId,
+            Registration = registrationInput
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Patch, $"v1/registrations/{updateRegistrationRequest.RegistrationId}")
+        {
+            Content = JsonContent.Create(updateRegistrationRequest)
+        };
+
+        // Act
+        var response = await CreateAuthenticatedClient().SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problemDetails = await response.Content.ReadFromJsonAsync<Microsoft.AspNetCore.Mvc.ProblemDetails>(TestContext.Current.CancellationToken);
+
+        problemDetails.Should().NotBeNull();
+        problemDetails!.Title.Should().Be("Bad Request");
+        problemDetails.Detail.Should().Be("Error updating registration.");
+        problemDetails.Extensions.Should().ContainKey("errors");
+
+        var errorsJson = (JsonElement)problemDetails.Extensions["errors"]!;
+        errorsJson.ValueKind.Should().Be(JsonValueKind.Array);
+
+        var errors = errorsJson.EnumerateArray().ToList();
+        errors.Should().ContainSingle();
+
+        var firstError = errors.First();
+        firstError.GetProperty("code").GetString().Should().Be("Registration.BowlerHasBowled");
+        firstError.GetProperty("description").GetString().Should().Be("Bowler has already bowled in removed squads.");
+        firstError.GetProperty("RemovedSquadIds").GetString().Should().Be(squads[0].Id.ToString());
+
+        var verifyRegistration = await _dbContext.Registrations
+            .Include(registration => registration.Squads)
+            .AsNoTrackingWithIdentityResolution()
+            .SingleAsync(registration => registration.Id == updateRegistrationRequest.RegistrationId, TestContext.Current.CancellationToken);
+
+        verifyRegistration.Squads.Should()
+            .HaveCount(3)
+            .And
+            .Contain(squad => squad.SquadId == squads[0].Id);
+    }
+
+    [Fact]
+    public async Task UpdateRegistration_ShouldReturn400_WhenTryingToEnterSuperSweeperButNotInEverySweeper()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+
+        var tournament = TournamentEntityFactory.Bogus();
+        var division = DivisionEntityFactory.Create(tournament.Id);
+        var squads = SquadEntityFactory.Bogus(3, tournament.Id).ToList();
+        var sweepers = SweeperEntityFactory.Bogus(2, tournament.Id);
+        var bowler = BowlerEntityFactory.Bogus();
+
+        var registration = RegistrationEntityFactory.Create(
+            bowler: bowler,
+            division: division,
+            squadIds: [squads.Select(s => s.Id).First()],
+            sweeperIds: [sweepers.Select(s => s.Id).First()],
+            superSweeper: false);
+
+        _dbContext.Tournaments.Add(tournament);
+        _dbContext.Divisions.Add(division);
+        _dbContext.Squads.AddRange(squads);
+        _dbContext.Sweepers.AddRange(sweepers);
+        _dbContext.Bowlers.Add(bowler);
+        _dbContext.Registrations.Add(registration);
+
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var registrationInput = new UpdateRegistrationInput
+        {
+            RegistrationId = registration.Id,
+            SuperSweeper = true
+        };
+
+        var updateRegistrationRequest = new UpdateRegistrationRequest
+        {
+            RegistrationId = registrationInput.RegistrationId,
+            Registration = registrationInput
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Patch, $"v1/registrations/{updateRegistrationRequest.RegistrationId}")
+        {
+            Content = JsonContent.Create(updateRegistrationRequest)
+        };
+
+        // Act
+        var response = await CreateAuthenticatedClient().SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problemDetails = await response.Content.ReadFromJsonAsync<Microsoft.AspNetCore.Mvc.ProblemDetails>(TestContext.Current.CancellationToken);
+
+        problemDetails.Should().NotBeNull();
+        problemDetails!.Title.Should().Be("Bad Request");
+        problemDetails.Detail.Should().Be("Error updating registration.");
+        problemDetails.Extensions.Should().ContainKey("errors");
+
+        var errorsJson = (JsonElement)problemDetails.Extensions["errors"]!;
+        errorsJson.ValueKind.Should().Be(JsonValueKind.Array);
+
+        var errors = errorsJson.EnumerateArray().ToList();
+        errors.Should().ContainSingle();
+
+        var firstError = errors.First();
+        firstError.GetProperty("code").GetString().Should().Be("Registration.InvalidSuperSweeper");
+        firstError.GetProperty("description").GetString().Should().Be("Cannot set Super Sweeper when not all sweepers are registered.");
+
+        var verifyRegistration = await _dbContext.Registrations
+            .Include(registration => registration.Squads)
+            .AsNoTrackingWithIdentityResolution()
+            .SingleAsync(registration => registration.Id == updateRegistrationRequest.RegistrationId, TestContext.Current.CancellationToken);
+
+        verifyRegistration.SuperSweeper.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateRegistration_ShouldReturn400_WhenTryingToSwitchDivisionWithDifferentGender()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+
+        var tournament = TournamentEntityFactory.Bogus();
+        var divisionM = DivisionEntityFactory.Create(tournament.Id, gender: Models.Gender.Male);
+        var divisionF = DivisionEntityFactory.Create(tournament.Id, gender: Models.Gender.Female);
+        var squads = SquadEntityFactory.Bogus(3, tournament.Id).ToList();
+        var sweepers = SweeperEntityFactory.Bogus(2, tournament.Id);
+        var bowler = BowlerEntityFactory.Bogus();
+
+        divisionM.MaximumAge = null;
+        divisionF.MaximumAge = null;
+        divisionM.MinimumAge = null;
+        divisionF.MinimumAge = null;
+        divisionM.HandicapBase = null;
+        divisionF.HandicapBase = null;
+        divisionM.HandicapPercentage = null;
+        divisionF.HandicapPercentage = null;
+        divisionM.MaximumHandicapPerGame = null;
+        divisionF.MaximumHandicapPerGame = null;
+
+        var registration = RegistrationEntityFactory.Create(
+            bowler: bowler,
+            division: bowler.Gender == Models.Gender.Male ? divisionM : divisionF,
+            squadIds: [squads.Select(s => s.Id).First()],
+            sweeperIds: [sweepers.Select(s => s.Id).First()],
+            superSweeper: false);
+
+        _dbContext.Tournaments.Add(tournament);
+        _dbContext.Divisions.AddRange(divisionM, divisionF);
+        _dbContext.Squads.AddRange(squads);
+        _dbContext.Sweepers.AddRange(sweepers);
+        _dbContext.Bowlers.Add(bowler);
+        _dbContext.Registrations.Add(registration);
+
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var registrationInput = new UpdateRegistrationInput
+        {
+            RegistrationId = registration.Id,
+            DivisionId = bowler.Gender == Models.Gender.Male ? divisionF.Id : divisionM.Id
+        };
+
+        var updateRegistrationRequest = new UpdateRegistrationRequest
+        {
+            RegistrationId = registrationInput.RegistrationId,
+            Registration = registrationInput
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Patch, $"v1/registrations/{updateRegistrationRequest.RegistrationId}")
+        {
+            Content = JsonContent.Create(updateRegistrationRequest)
+        };
+
+        // Act
+        var response = await CreateAuthenticatedClient().SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problemDetails = await response.Content.ReadFromJsonAsync<Microsoft.AspNetCore.Mvc.ProblemDetails>(TestContext.Current.CancellationToken);
+
+        problemDetails.Should().NotBeNull();
+        problemDetails!.Title.Should().Be("Bad Request");
+        problemDetails.Detail.Should().Be("Error updating registration.");
+        problemDetails.Extensions.Should().ContainKey("errors");
+
+        var errorsJson = (JsonElement)problemDetails.Extensions["errors"]!;
+        errorsJson.ValueKind.Should().Be(JsonValueKind.Array);
+
+        var errors = errorsJson.EnumerateArray().ToList();
+        errors.Should().ContainSingle();
+
+        var firstError = errors.First();
+        firstError.GetProperty("description").GetString().Should().Be("Invalid gender for selected division");
+
+        var verifyRegistration = await _dbContext.Registrations
+            .Include(registration => registration.Squads)
+            .AsNoTrackingWithIdentityResolution()
+            .SingleAsync(registration => registration.Id == updateRegistrationRequest.RegistrationId, TestContext.Current.CancellationToken);
+
+        verifyRegistration.DivisionId.Should().Be(bowler.Gender == Models.Gender.Male ? divisionM.Id : divisionF.Id);
+    }
+
+    [Fact]
+    public async Task UpdateRegistration_ShouldReturn204_WhenRegistrationUpdatesSuccessfully()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+
+        var tournament = TournamentEntityFactory.Bogus();
+        var division = DivisionEntityFactory.Create(tournament.Id);
+        var squads = SquadEntityFactory.Bogus(3, tournament.Id).ToList();
+        var sweepers = SweeperEntityFactory.Bogus(3, tournament.Id).ToList();
+        var bowler = BowlerEntityFactory.Bogus();
+
+        var registration = RegistrationEntityFactory.Create(
+            bowler: bowler,
+            division: division,
+            squadIds: squads.Select(s => s.Id).Take(2),
+            sweeperIds: sweepers.Select(s => s.Id).Take(2),
+            superSweeper: false);
+
+        var newDivision = new Division
+        {
+            Id = DivisionId.New(),
+            TournamentId = tournament.Id,
+            HandicapPercentage = .9m,
+            HandicapBase = 210,
+            MaximumHandicapPerGame = 25
+        };
+
+        _dbContext.Tournaments.Add(tournament);
+        _dbContext.Divisions.AddRange(division, newDivision);
+        _dbContext.Squads.AddRange(squads);
+        _dbContext.Sweepers.AddRange(sweepers);
+        _dbContext.Bowlers.Add(bowler);
+        _dbContext.Registrations.Add(registration);
+
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var registrationInput = new UpdateRegistrationInput
+        {
+            RegistrationId = registration.Id,
+            DivisionId = newDivision.Id,
+            SquadIds = [squads[0].Id, squads[2].Id],
+            SweeperIds = [sweepers[0].Id, sweepers[1].Id, sweepers[2].Id],
+            Average = 200,
+            SuperSweeper = true
+        };
+
+        var updateRegistrationRequest = new UpdateRegistrationRequest
+        {
+            RegistrationId = registrationInput.RegistrationId,
+            Registration = registrationInput
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Patch, $"v1/registrations/{updateRegistrationRequest.RegistrationId}")
+        {
+            Content = JsonContent.Create(updateRegistrationRequest)
+        };
+
+        // Act
+        var response = await CreateAuthenticatedClient().SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var verifyRegistration = await _dbContext.Registrations
+            .Include(registration => registration.Squads)
+            .AsNoTrackingWithIdentityResolution()
+            .SingleAsync(registration => registration.Id == updateRegistrationRequest.RegistrationId, TestContext.Current.CancellationToken);
+
+        verifyRegistration.DivisionId.Should().Be(newDivision.Id);
+        verifyRegistration.Squads.Should().HaveCount(5)
+            .And.Contain(squad => squad.SquadId == squads[0].Id)
+            .And.Contain(squad => squad.SquadId == squads[2].Id)
+            .And.Contain(squad => squad.SquadId == sweepers[0].Id)
+            .And.Contain(squad => squad.SquadId == sweepers[1].Id)
+            .And.Contain(squad => squad.SquadId == sweepers[2].Id);
+        verifyRegistration.Average.Should().Be(200);
+        verifyRegistration.SuperSweeper.Should().BeTrue();
+    }
+}

--- a/source/tests/BowlingMegabucks.TournamentManager.UnitTests/Registrations/RegistrationEntityMapperTests.cs
+++ b/source/tests/BowlingMegabucks.TournamentManager.UnitTests/Registrations/RegistrationEntityMapperTests.cs
@@ -5,6 +5,7 @@ namespace BowlingMegabucks.TournamentManager.UnitTests.Registrations;
 internal sealed class EntityMapper
 {
     private Mock<TournamentManager.Bowlers.IEntityMapper> _bowlerEntityMapper;
+    private TournamentManager.Registrations.IPaymentEntityMapper _paymentEntityMapper;
 
     private TournamentManager.Registrations.EntityMapper _mapper;
 
@@ -12,8 +13,9 @@ internal sealed class EntityMapper
     public void SetUp()
     {
         _bowlerEntityMapper = new Mock<TournamentManager.Bowlers.IEntityMapper>();
+        _paymentEntityMapper = new TournamentManager.Registrations.PaymentEntityMapper();
 
-        _mapper = new TournamentManager.Registrations.EntityMapper(_bowlerEntityMapper.Object);
+        _mapper = new TournamentManager.Registrations.EntityMapper(_bowlerEntityMapper.Object, _paymentEntityMapper);
     }
 
     [Test]

--- a/source/tests/BowlingMegabucks.TournamentManager.UnitTests/Registrations/UpdateRegistration/UpdateRegistrationCommandHandlerTests.cs
+++ b/source/tests/BowlingMegabucks.TournamentManager.UnitTests/Registrations/UpdateRegistration/UpdateRegistrationCommandHandlerTests.cs
@@ -1,3 +1,7 @@
+using System.Linq.Expressions;
+using BowlingMegabucks.TournamentManager.Database.Entities;
+using BowlingMegabucks.TournamentManager.Registrations.UpdateRegistration;
+using ErrorOr;
 using FluentValidation;
 
 namespace BowlingMegabucks.TournamentManager.UnitTests.Registrations.UpdateRegistration;
@@ -7,18 +11,18 @@ public sealed class UpdateRegistrationCommandHandlerTests
 {
     private Mock<TournamentManager.Registrations.IRepository> _mockRegistrationRepository;
     private Mock<TournamentManager.Scores.IRepository> _mockScoresRepository;
-    private IValidator<TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationRecord> _registrationValidator;
+    private IValidator<UpdateRegistrationRecord> _registrationValidator;
     private Mock<TournamentManager.Tournaments.IRepository> _mockTournamentRepository;
     private TournamentManager.Registrations.IPaymentEntityMapper _paymentEntityMapper;
 
-    private TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommandHandler _handler;
+    private UpdateRegistrationCommandHandler _handler;
 
     [SetUp]
     public void SetUp()
     {
         _mockRegistrationRepository = new Mock<TournamentManager.Registrations.IRepository>();
         _mockScoresRepository = new Mock<TournamentManager.Scores.IRepository>();
-        _registrationValidator = new InlineValidator<TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationRecord>();
+        _registrationValidator = new Validator();
         _mockTournamentRepository = new Mock<TournamentManager.Tournaments.IRepository>();
         _paymentEntityMapper = new TournamentManager.Registrations.PaymentEntityMapper();
 
@@ -28,5 +32,2485 @@ public sealed class UpdateRegistrationCommandHandlerTests
             _mockTournamentRepository.Object,
             _paymentEntityMapper,
             _registrationValidator);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenRegistrationIsNotFound()
+    {
+        // Arrange
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = RegistrationId.New()
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(command.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Registration)null);
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.NotFound));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Registration.NotFound"));
+        Assert.That(result.FirstError.Description, Is.EqualTo($"Registration with ID {command.Id} not found."));
+
+        _mockRegistrationRepository.Verify(repository => repository.RetrieveAsync(command.Id, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenASquadIdProvidedDoesNotBelongToTheTournament()
+    {
+        // Arrange
+        var validSquad1 = SquadId.New();
+        var validSquad2 = SquadId.New();
+        var validSweeper1 = SquadId.New();
+        var validSweeper2 = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads = [.. new List<SquadId> { validSquad1, validSquad2 }
+                .Select(squadId => new TournamentSquad { Id = squadId })],
+            Sweepers = [.. new List<SquadId> { validSweeper1, validSweeper2 }
+                .Select(squadId => new SweeperSquad { Id = squadId })],
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads = []
+        };
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var invalidSquadId1 = SquadId.New();
+        var invalidSquadId2 = SquadId.New();
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SquadIds = [validSquad1, invalidSquadId1, invalidSquadId2] // Invalid squad ID
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Registration.InvalidSquadIds"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("Invalid squad IDs"));
+        Assert.That(result.FirstError.Metadata["InvalidSquadIds"], Is.EqualTo($"{invalidSquadId1}, {invalidSquadId2}"));
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenASweeperIdProvidedDoesNotBelongToTheTournament()
+    {
+        // Arrange
+        var validSquad1 = SquadId.New();
+        var validSquad2 = SquadId.New();
+        var validSweeper1 = SquadId.New();
+        var validSweeper2 = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads = [.. new List<SquadId> { validSquad1, validSquad2 }
+                .Select(squadId => new TournamentSquad { Id = squadId })],
+            Sweepers = [.. new List<SquadId> { validSweeper1, validSweeper2 }
+                .Select(squadId => new SweeperSquad { Id = squadId })],
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads = []
+        };
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.Setup(repo => repo.BowlerScoresForSquads(existingRegistration.BowlerId, It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SquadScore>());
+
+        var invalidSweeperId1 = SquadId.New();
+        var invalidSweeperId2 = SquadId.New();
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SweeperIds = [validSweeper1, invalidSweeperId1, invalidSweeperId2] // Invalid sweeper IDs
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Registration.InvalidSweeperIds"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("Invalid sweeper IDs"));
+        Assert.That(result.FirstError.Metadata["InvalidSweeperIds"], Is.EqualTo($"{invalidSweeperId1}, {invalidSweeperId2}"));
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenAddedSquadHasAlreadyBeenCompleted()
+    {
+        // Arrange
+        var completedSquadId1 = SquadId.New();
+        var completedSquadId2 = SquadId.New();
+
+        var nonCompletedSquadId = SquadId.New();
+        var otherTournamentSquad = SquadId.New();
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads = [.. new List<SquadId> { completedSquadId1, completedSquadId2, nonCompletedSquadId, otherTournamentSquad }
+                .Select(squadId => new TournamentSquad { Id = squadId, Complete = new[] {completedSquadId1,completedSquadId2}.Contains(squadId) })],
+            Sweepers = [.. new List<SquadId> { SquadId.New(), SquadId.New() }
+                .Select(squadId => new SweeperSquad { Id = squadId, Complete = false })],
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads = [new SquadRegistration { SquadId = otherTournamentSquad, RegistrationId = registrationId }]
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SquadIds = [completedSquadId1, completedSquadId2, nonCompletedSquadId, otherTournamentSquad]
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Registration.InvalidSquadIds"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("Cannot add squad(s) that are already complete."));
+        Assert.That(result.FirstError.Metadata["InvalidSquadIds"], Is.EqualTo($"{completedSquadId1}, {completedSquadId2}"));
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenAddedSweeperHasAlreadyBeenCompleted()
+    {
+        // Arrange
+        var completedSquadId1 = SquadId.New();
+        var completedSquadId2 = SquadId.New();
+
+        var nonCompletedSquadId = SquadId.New();
+        var otherTournamentSquad = SquadId.New();
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads = [.. new List<SquadId> { SquadId.New(), SquadId.New() }
+                .Select(squadId => new TournamentSquad { Id = squadId })],
+            Sweepers = [.. new List<SquadId> { completedSquadId1, completedSquadId2, nonCompletedSquadId, otherTournamentSquad }
+                .Select(squadId => new SweeperSquad { Id = squadId, Complete = new[] {completedSquadId1,completedSquadId2}.Contains(squadId) })]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads = [new SquadRegistration { SquadId = otherTournamentSquad, RegistrationId = registrationId }]
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.Setup(repo => repo.BowlerScoresForSquads(existingRegistration.BowlerId, It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SquadScore>());
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SweeperIds = [completedSquadId1, completedSquadId2, nonCompletedSquadId, otherTournamentSquad]
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Registration.InvalidSweeperIds"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("Cannot add sweeper(s) that are already complete."));
+        Assert.That(result.FirstError.Metadata["InvalidSweeperIds"], Is.EqualTo($"{completedSquadId1}, {completedSquadId2}"));
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenBowlerHasBowledInARemovedSquad()
+    {
+        // Arrange
+        var bowledSquadId = SquadId.New();
+        var squadIdToAdd = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads = [.. new List<SquadId> { bowledSquadId, squadIdToAdd }
+                .Select(squadId => new TournamentSquad { Id = squadId })],
+            Sweepers = [.. new List<SquadId> { SquadId.New()}
+                .Select(squadId => new SweeperSquad { Id = squadId })]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads = [new SquadRegistration { SquadId = bowledSquadId, Squad = new TournamentSquad { Id = bowledSquadId }, RegistrationId = registrationId }]
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.Setup(repo => repo.BowlerScoresForSquads(existingRegistration.BowlerId, It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([.. new List<SquadScore> { new() { SquadId = bowledSquadId, BowlerId = existingRegistration.BowlerId, Score = 200, Game = 1 } }]);
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SquadIds = [squadIdToAdd]
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Registration.BowlerHasBowled"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("Bowler has already bowled in removed squads."));
+        Assert.That(result.FirstError.Metadata["RemovedSquadIds"], Is.EqualTo($"{bowledSquadId}"));
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenBowlerHasBowledInARemovedSweeper()
+    {
+        // Arrange
+        var bowledSquadId = SquadId.New();
+        var squadIdToAdd = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Sweepers = [.. new List<SquadId> { bowledSquadId, squadIdToAdd }
+                .Select(squadId => new SweeperSquad { Id = squadId })],
+            Squads = [.. new List<SquadId> { SquadId.New()}
+                .Select(squadId => new TournamentSquad { Id = squadId })]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads = [new SquadRegistration { SquadId = bowledSquadId, Squad = new SweeperSquad { Id = bowledSquadId }, RegistrationId = registrationId }]
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.SetupSequence(repo => repo.BowlerScoresForSquads(existingRegistration.BowlerId, It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SquadScore>())
+            .ReturnsAsync([.. new List<SquadScore> { new() { SquadId = bowledSquadId, BowlerId = existingRegistration.BowlerId, Score = 200, Game = 1 } }]);
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SweeperIds = [squadIdToAdd]
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Registration.BowlerHasBowled"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("Bowler has already bowled in removed sweeper(s)."));
+        Assert.That(result.FirstError.Metadata["RemovedSweeperIds"], Is.EqualTo($"{bowledSquadId}"));
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldUpdateRegistration_WhenOnlySquadsAreChangedAndIsAValidChange()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var squadId3 = SquadId.New();
+
+        var squadId4 = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new() { Id = squadId1 },
+                new() { Id = squadId2 },
+                new() { Id = squadId3 }
+            ],
+            Sweepers =
+            [
+                new() { Id = squadId4 },
+                new() { Id = SquadId.New() }
+            ]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads =
+            [
+                new SquadRegistration { SquadId = squadId1, Squad = new TournamentSquad { Id = squadId1 }, RegistrationId = registrationId },
+                new SquadRegistration { SquadId = squadId4, Squad = new SweeperSquad { Id = squadId4 }, RegistrationId = registrationId }
+            ]
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.Setup(repo => repo.BowlerScoresForSquads(existingRegistration.BowlerId, It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SquadScore>());
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SquadIds = [squadId2, squadId3]
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.False);
+        Assert.That(result.Value, Is.EqualTo(Result.Updated));
+
+        Expression<Func<Registration, bool>> validSquadIds =
+            registration => registration.Squads.Select(s => s.SquadId).Count() == 3
+                && registration.Squads.Any(s => s.SquadId == squadId2)
+                && registration.Squads.Any(s => s.SquadId == squadId3)
+                && registration.Squads.Any(s => s.SquadId == squadId4);
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.Is(validSquadIds), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenNotAllSweepersAreRegisteredAndSuperSweeperWasTrue()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var squadId3 = SquadId.New();
+
+        var squadId4 = SquadId.New();
+        var squadId5 = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new() { Id = squadId1 },
+                new() { Id = squadId2 },
+                new() { Id = squadId3 }
+            ],
+            Sweepers =
+            [
+                new() { Id = squadId4 },
+                new() { Id = squadId5 }
+            ]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads =
+            [
+                new SquadRegistration { SquadId = squadId1, Squad = new TournamentSquad { Id = squadId1 }, RegistrationId = registrationId },
+
+                new SquadRegistration { SquadId = squadId4, Squad = new SweeperSquad { Id = squadId4 }, RegistrationId = registrationId }
+            ],
+            SuperSweeper = true
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.Setup(repo => repo.BowlerScoresForSquads(existingRegistration.BowlerId, It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SquadScore>());
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SweeperIds = [squadId4]
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Registration.NotAllSweepersRegistered"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("Super Sweeper cannot be enrolled when not all sweepers are registered."));
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenNotAllUpdatedSweepersAreRegistered([Values] bool superSweeper)
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var squadId3 = SquadId.New();
+
+        var squadId4 = SquadId.New();
+        var squadId5 = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new() { Id = squadId1 },
+                new() { Id = squadId2 },
+                new() { Id = squadId3 }
+            ],
+            Sweepers =
+            [
+                new() { Id = squadId4 },
+                new() { Id = squadId5 }
+            ]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads =
+            [
+                new SquadRegistration { SquadId = squadId1, Squad = new TournamentSquad { Id = squadId1 }, RegistrationId = registrationId },
+
+                new SquadRegistration { SquadId = squadId4, Squad = new SweeperSquad { Id = squadId4 }, RegistrationId = registrationId },
+                new SquadRegistration { SquadId = squadId5, Squad = new SweeperSquad { Id = squadId5 }, RegistrationId = registrationId }
+            ],
+            SuperSweeper = superSweeper
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.Setup(repo => repo.BowlerScoresForSquads(existingRegistration.BowlerId, It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SquadScore>());
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SweeperIds = [squadId4],
+            SuperSweeper = true
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Registration.NotAllSweepersRegistered"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("Super Sweeper cannot be enrolled when not all sweepers are registered."));
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldUpdateRegistration_WhenOnlySweepersAreChangedAndIsAValidChange()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var squadId3 = SquadId.New();
+
+        var squadId4 = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Sweepers =
+            [
+                new() { Id = squadId1 },
+                new() { Id = squadId2 },
+                new() { Id = squadId3 }
+            ],
+            Squads =
+            [
+                new() { Id = squadId4 },
+                new() { Id = SquadId.New() }
+            ]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads =
+            [
+                new SquadRegistration { SquadId = squadId1, Squad = new SweeperSquad { Id = squadId1 }, RegistrationId = registrationId },
+                new SquadRegistration { SquadId = squadId4, Squad = new TournamentSquad { Id = squadId4 }, RegistrationId = registrationId }
+            ]
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.Setup(repo => repo.BowlerScoresForSquads(existingRegistration.BowlerId, It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SquadScore>());
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SweeperIds = [squadId2, squadId3]
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.False);
+        Assert.That(result.Value, Is.EqualTo(Result.Updated));
+
+        Expression<Func<Registration, bool>> validSquadIds =
+            registration => registration.Squads.Select(s => s.SquadId).Count() == 3
+                && registration.Squads.Any(s => s.SquadId == squadId2)
+                && registration.Squads.Any(s => s.SquadId == squadId3)
+                && registration.Squads.Any(s => s.SquadId == squadId4);
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.Is(validSquadIds), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldUpdateRegistration_WhenSquadsAndSweepersAreChanged()
+    {
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var squadId3 = SquadId.New();
+
+        var sweeperId1 = SquadId.New();
+        var sweeperId2 = SquadId.New();
+        var sweeperId3 = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new() { Id = squadId1 },
+                new() { Id = squadId2 },
+                new() { Id = squadId3 }
+            ],
+            Sweepers =
+            [
+                new() { Id = sweeperId1 },
+                new() { Id = sweeperId2 },
+                new() { Id = sweeperId3 }
+            ]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads =
+            [
+                new SquadRegistration { SquadId = squadId1, Squad = new TournamentSquad { Id = squadId1 }, RegistrationId = registrationId },
+                new SquadRegistration { SquadId = squadId2, Squad = new TournamentSquad { Id = squadId2 }, RegistrationId = registrationId },
+                new SquadRegistration { SquadId = sweeperId1, Squad = new SweeperSquad { Id = sweeperId1 }, RegistrationId = registrationId },
+                new SquadRegistration { SquadId = sweeperId2, Squad = new SweeperSquad { Id = sweeperId2 }, RegistrationId = registrationId }
+            ]
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.Setup(repo => repo.BowlerScoresForSquads(existingRegistration.BowlerId, It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SquadScore>());
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SquadIds = [squadId2, squadId3],
+            SweeperIds = [sweeperId2, sweeperId3]
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.False);
+        Assert.That(result.Value, Is.EqualTo(Result.Updated));
+
+        Expression<Func<Registration, bool>> validSquadIds =
+            registration => registration.Squads.Select(s => s.SquadId).Count() == 4
+                && registration.Squads.Any(s => s.SquadId == squadId2)
+                && registration.Squads.Any(s => s.SquadId == squadId3)
+                && registration.Squads.Any(s => s.SquadId == sweeperId2)
+                && registration.Squads.Any(s => s.SquadId == sweeperId3);
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.Is(validSquadIds), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenTryingToUpdateSuperSweeperWhenSweeperScoresHaveBeenBowled([Values] bool superSweeper)
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+
+        var sweeperId1 = SquadId.New();
+        var sweeperId2 = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new() { Id = squadId1 }
+            ],
+            Sweepers =
+            [
+                new() { Id = sweeperId1 },
+                new() { Id = sweeperId2 }
+            ]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads =
+            [
+                new SquadRegistration { SquadId = squadId1, Squad = new TournamentSquad { Id = squadId1 }, RegistrationId = registrationId },
+                new SquadRegistration { SquadId = sweeperId1, Squad = new SweeperSquad { Id = sweeperId1 }, RegistrationId = registrationId },
+                new SquadRegistration { SquadId = sweeperId2, Squad = new SweeperSquad { Id = sweeperId2 }, RegistrationId = registrationId }
+            ]
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.Setup(repo => repo.Retrieve(It.Is<SquadId[]>(squadIds => squadIds.Contains(sweeperId1) || squadIds.Contains(sweeperId2))))
+            .Returns(new List<SquadScore> {
+            new()
+            {
+                SquadId = sweeperId1,
+                BowlerId = existingRegistration.BowlerId,
+                Score = 200,
+                Game = 1
+            }}.AsQueryable());
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SuperSweeper = superSweeper
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Registration.SuperSweeperScoresExist"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("Cannot change Super Sweeper when sweeper scores have been recorded."));
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldUpdateRegistration_WhenSuperSweeperIsSetToFalse([Values] bool superSweeper)
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+
+        var sweeperId1 = SquadId.New();
+        var sweeperId2 = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new() { Id = squadId1 }
+            ],
+            Sweepers =
+            [
+                new() { Id = sweeperId1 },
+                new() { Id = sweeperId2 }
+            ]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads =
+            [
+                new SquadRegistration { SquadId = squadId1, Squad = new TournamentSquad { Id = squadId1 }, RegistrationId = registrationId },
+                new SquadRegistration { SquadId = sweeperId1, Squad = new SweeperSquad { Id = sweeperId1 }, RegistrationId = registrationId },
+                new SquadRegistration { SquadId = sweeperId2, Squad = new SweeperSquad { Id = sweeperId2 }, RegistrationId = registrationId }
+            ],
+            SuperSweeper = superSweeper
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.Setup(repo => repo.Retrieve(It.Is<SquadId[]>(squadIds => squadIds.Contains(sweeperId1) || squadIds.Contains(sweeperId2))))
+            .Returns(new List<SquadScore>().AsQueryable());
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SuperSweeper = false
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.False);
+        Assert.That(result.Value, Is.EqualTo(Result.Updated));
+
+        Expression<Func<Registration, bool>> validSquadIds =
+            registration => registration.Squads.Select(s => s.SquadId).Count() == 3
+                && registration.Squads.Any(s => s.SquadId == squadId1)
+                && registration.Squads.Any(s => s.SquadId == sweeperId1)
+                && registration.Squads.Any(s => s.SquadId == sweeperId2)
+                && !registration.SuperSweeper;
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.Is(validSquadIds), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenSuperSweeperIsSetToTrueAndNotAllSweepersArePreviouslyRegistered()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+
+        var sweeperId1 = SquadId.New();
+        var sweeperId2 = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new() { Id = squadId1 }
+            ],
+            Sweepers =
+            [
+                new() { Id = sweeperId1 },
+                new() { Id = sweeperId2 }
+            ]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads =
+            [
+                new SquadRegistration { SquadId = squadId1, Squad = new TournamentSquad { Id = squadId1 }, RegistrationId = registrationId },
+                new SquadRegistration { SquadId = sweeperId1, Squad = new SweeperSquad { Id = sweeperId1 }, RegistrationId = registrationId }
+            ],
+            SuperSweeper = true
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.Setup(repo => repo.Retrieve(It.Is<SquadId[]>(squadIds => squadIds.Contains(sweeperId1) || squadIds.Contains(sweeperId2))))
+            .Returns(new List<SquadScore>().AsQueryable());
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+
+            SuperSweeper = true
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Registration.InvalidSuperSweeper"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("Cannot set Super Sweeper when not all sweepers are registered."));
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldUpdateRegistration_WhenSuperSweeperIsSetToTrueAndSweeperUpdateDoesContainAllSweepers()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+
+        var sweeperId1 = SquadId.New();
+        var sweeperId2 = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new() { Id = squadId1 }
+            ],
+            Sweepers =
+            [
+                new() { Id = sweeperId1 },
+                new() { Id = sweeperId2 }
+            ]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads =
+            [
+                new SquadRegistration { SquadId = squadId1, Squad = new TournamentSquad { Id = squadId1 }, RegistrationId = registrationId },
+                new SquadRegistration { SquadId = sweeperId1, Squad = new SweeperSquad { Id = sweeperId1 }, RegistrationId = registrationId },
+            ],
+            SuperSweeper = false
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.Setup(repo => repo.BowlerScoresForSquads(existingRegistration.BowlerId, It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new List<SquadScore>());
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SweeperIds = new[] { sweeperId1, sweeperId2 },
+            SuperSweeper = true
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.False);
+        Assert.That(result.Value, Is.EqualTo(Result.Updated));
+
+        Expression<Func<Registration, bool>> validSquadIds =
+            registration => registration.Squads.Select(s => s.SquadId).Count() == 3
+                && registration.Squads.Any(s => s.SquadId == squadId1)
+                && registration.Squads.Any(s => s.SquadId == sweeperId1)
+                && registration.Squads.Any(s => s.SquadId == sweeperId2)
+                && registration.SuperSweeper;
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.Is(validSquadIds), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldUpdateRegistration_WhenSuperSweeperIsSetToTrueAndAllSweepersAreAlreadyRegistered()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+
+        var sweeperId1 = SquadId.New();
+        var sweeperId2 = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new() { Id = squadId1 }
+            ],
+            Sweepers =
+            [
+                new() { Id = sweeperId1 },
+                new() { Id = sweeperId2 }
+            ]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads =
+            [
+                new SquadRegistration { SquadId = squadId1, Squad = new TournamentSquad { Id = squadId1 }, RegistrationId = registrationId },
+
+                new SquadRegistration { SquadId = sweeperId1, Squad = new SweeperSquad { Id = sweeperId1 }, RegistrationId = registrationId },
+                new SquadRegistration { SquadId = sweeperId2, Squad = new SweeperSquad { Id = sweeperId2 }, RegistrationId = registrationId }
+            ],
+            SuperSweeper = false
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _mockScoresRepository.Setup(repo => repo.BowlerScoresForSquads(existingRegistration.BowlerId, It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new List<SquadScore>());
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            SuperSweeper = true
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.False);
+        Assert.That(result.Value, Is.EqualTo(Result.Updated));
+
+        Expression<Func<Registration, bool>> validSquadIds =
+            registration => registration.Squads.Select(s => s.SquadId).Count() == 3
+                && registration.Squads.Any(s => s.SquadId == squadId1)
+                && registration.Squads.Any(s => s.SquadId == sweeperId1)
+                && registration.Squads.Any(s => s.SquadId == sweeperId2)
+                && registration.SuperSweeper;
+
+        _mockTournamentRepository.Verify(repository => repository.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.Is(validSquadIds), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenDivisionIdDoesNotExistForTournament()
+    {
+        // Assert
+        var tournamentDivisionId1 = DivisionId.New();
+        var tournamentDivisionId2 = DivisionId.New();
+
+        var tournament = new Tournament
+        {
+            Divisions =
+            [
+                new () { Id = tournamentDivisionId1 },
+                new () { Id = tournamentDivisionId2 }
+            ]
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division
+            {
+                Id = tournamentDivisionId1,
+                TournamentId = tournament.Id,
+                Tournament = tournament
+            },
+            Squads = [],
+            SuperSweeper = false
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(existingRegistration.Division.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var command = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = DivisionId.New()
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Registration.InvalidDivisionId"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("Division ID is not valid for the tournament."));
+        Assert.That(result.FirstError.Metadata["ValidDivisionIds"], Is.EqualTo($"{tournamentDivisionId1}, {tournamentDivisionId2}"));
+
+        _mockRegistrationRepository.Verify(repository => repository.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenExistingAverageIsNullAndDivisionHasMinAverage()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperId = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+                new () { Id = squadId2 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId }
+            ]
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var currentDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+
+        var currentDivision = new Division
+        {
+            Id = currentDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+        var newDivision = new Division
+        {
+            Id = newDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+
+        tournament.Divisions =
+        [
+            currentDivision,
+            newDivision
+        ];
+
+        var bowler = new Bowler
+        {
+            Id = BowlerId.New()
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = bowler.Id,
+            Bowler = bowler,
+            Division = currentDivision,
+            Squads = [.. new[] {squadId1, squadId2}.Select(s => new SquadRegistration
+            {
+                SquadId = s,
+                Squad = new TournamentSquad { Id = s },
+                RegistrationId = registrationId
+            })],
+            SuperSweeper = false,
+            Average = 200
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        existingRegistration.Average = null;
+        newDivision.MinimumAverage = 200;
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = newDivisionId
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.Errors.All(e => e.Type == ErrorType.Validation), Is.True);
+        Assert.That(result.Errors.Any(e => e.Description == "Average is required for selected division"), Is.True);
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenExistingAverageIsNullAndDivisionHasMaxAverage()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperId = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+                new () { Id = squadId2 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId }
+            ]
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var currentDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+
+        var currentDivision = new Division
+        {
+            Id = currentDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+        var newDivision = new Division
+        {
+            Id = newDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+
+        tournament.Divisions =
+        [
+            currentDivision,
+            newDivision
+        ];
+
+        var bowler = new Bowler
+        {
+            Id = BowlerId.New()
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = bowler.Id,
+            Bowler = bowler,
+            Division = currentDivision,
+            Squads = [.. new[] {squadId1, squadId2}.Select(s => new SquadRegistration
+            {
+                SquadId = s,
+                Squad = new TournamentSquad { Id = s },
+                RegistrationId = registrationId
+            })],
+            SuperSweeper = false,
+            Average = 200
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        existingRegistration.Average = null;
+        newDivision.MaximumAverage = 200;
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = newDivisionId
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.Errors.All(e => e.Type == ErrorType.Validation), Is.True);
+        Assert.That(result.Errors.Any(e => e.Description == "Average is required for selected division"), Is.True);
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenExistingAverageIsNullAndDivisionHasMinAndMaxAverage()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperId = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+                new () { Id = squadId2 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId }
+            ]
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var currentDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+
+        var currentDivision = new Division
+        {
+            Id = currentDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+        var newDivision = new Division
+        {
+            Id = newDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+
+        tournament.Divisions =
+        [
+            currentDivision,
+            newDivision
+        ];
+
+        var bowler = new Bowler
+        {
+            Id = BowlerId.New()
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = bowler.Id,
+            Bowler = bowler,
+            Division = currentDivision,
+            Squads = [.. new[] {squadId1, squadId2}.Select(s => new SquadRegistration
+            {
+                SquadId = s,
+                Squad = new TournamentSquad { Id = s },
+                RegistrationId = registrationId
+            })],
+            SuperSweeper = false,
+            Average = 200
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        existingRegistration.Average = null;
+        newDivision.MinimumAverage = 200;
+        newDivision.MaximumAverage = 300;
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = newDivisionId
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.Errors.All(e => e.Type == ErrorType.Validation), Is.True);
+        Assert.That(result.Errors.Any(e => e.Description == "Average is required for selected division"), Is.True);
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenExistingAverageDoesNotMeetTheMinimumAverageRequirement()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperId = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+                new () { Id = squadId2 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId }
+            ]
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var currentDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+
+        var currentDivision = new Division
+        {
+            Id = currentDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+        var newDivision = new Division
+        {
+            Id = newDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+
+        tournament.Divisions =
+        [
+            currentDivision,
+            newDivision
+        ];
+
+        var bowler = new Bowler
+        {
+            Id = BowlerId.New()
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = bowler.Id,
+            Bowler = bowler,
+            Division = currentDivision,
+            Squads = [.. new[] {squadId1, squadId2}.Select(s => new SquadRegistration
+            {
+                SquadId = s,
+                Squad = new TournamentSquad { Id = s },
+                RegistrationId = registrationId
+            })],
+            SuperSweeper = false,
+            Average = 200
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        existingRegistration.Average = 200;
+        newDivision.MinimumAverage = 201;
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = newDivisionId
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.Errors.All(e => e.Type == ErrorType.Validation), Is.True);
+        Assert.That(result.Errors.Any(e => e.Description == "Minimum average requirement for division not met"), Is.True);
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenExistingAverageDoesNotMeetTheMaximumAverageRequirement()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperId = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+                new () { Id = squadId2 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId }
+            ]
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var currentDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+
+        var currentDivision = new Division
+        {
+            Id = currentDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+        var newDivision = new Division
+        {
+            Id = newDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+
+        tournament.Divisions =
+        [
+            currentDivision,
+            newDivision
+        ];
+
+        var bowler = new Bowler
+        {
+            Id = BowlerId.New()
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = bowler.Id,
+            Bowler = bowler,
+            Division = currentDivision,
+            Squads = [.. new[] {squadId1, squadId2}.Select(s => new SquadRegistration
+            {
+                SquadId = s,
+                Squad = new TournamentSquad { Id = s },
+                RegistrationId = registrationId
+            })],
+            SuperSweeper = false,
+            Average = 200
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        existingRegistration.Average = 201;
+        newDivision.MaximumAverage = 200;
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = newDivisionId
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.Errors.All(e => e.Type == ErrorType.Validation), Is.True);
+        Assert.That(result.Errors.Any(e => e.Description == "Maximum average requirement for division not met"), Is.True);
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenBowlerHasNoDateOfBirthWithMinimumAgeAndNoGenderInclusion()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperId = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+                new () { Id = squadId2 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId }
+            ]
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var currentDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+
+        var currentDivision = new Division
+        {
+            Id = currentDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+        var newDivision = new Division
+        {
+            Id = newDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+
+        tournament.Divisions =
+        [
+            currentDivision,
+            newDivision
+        ];
+
+        var bowler = new Bowler
+        {
+            Id = BowlerId.New()
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = bowler.Id,
+            Bowler = bowler,
+            Division = currentDivision,
+            Squads = [.. new[] {squadId1, squadId2}.Select(s => new SquadRegistration
+            {
+                SquadId = s,
+                Squad = new TournamentSquad { Id = s },
+                RegistrationId = registrationId
+            })],
+            SuperSweeper = false,
+            Average = 200
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        bowler.DateOfBirth = null;
+        newDivision.MinimumAge = 50;
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = newDivisionId
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.Errors.All(e => e.Type == ErrorType.Validation), Is.True);
+        Assert.That(result.Errors.Any(e => e.Description == "Date of birth required for selected division"), Is.True);
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenBowlerHasNoDateOfBirthWithMaximumAgeAndNoGenderInclusion()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperId = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+                new () { Id = squadId2 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId }
+            ]
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var currentDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+
+        var currentDivision = new Division
+        {
+            Id = currentDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+        var newDivision = new Division
+        {
+            Id = newDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+
+        tournament.Divisions =
+        [
+            currentDivision,
+            newDivision
+        ];
+
+        var bowler = new Bowler
+        {
+            Id = BowlerId.New()
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = bowler.Id,
+            Bowler = bowler,
+            Division = currentDivision,
+            Squads = [.. new[] {squadId1, squadId2}.Select(s => new SquadRegistration
+            {
+                SquadId = s,
+                Squad = new TournamentSquad { Id = s },
+                RegistrationId = registrationId
+            })],
+            SuperSweeper = false,
+            Average = 200
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        bowler.DateOfBirth = null;
+        newDivision.MaximumAge = 50;
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = newDivisionId
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.Errors.All(e => e.Type == ErrorType.Validation), Is.True);
+        Assert.That(result.Errors.Any(e => e.Description == "Date of birth required for selected division"), Is.True);
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenBowlerIsTooYoungAndNoGenderInclusion()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperId = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+                new () { Id = squadId2 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId }
+            ],
+            Start = new DateOnly(DateTime.Today.Year, DateTime.Today.Month, DateTime.Today.Day)
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var currentDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+
+        var currentDivision = new Division
+        {
+            Id = currentDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+        var newDivision = new Division
+        {
+            Id = newDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+
+        tournament.Divisions =
+        [
+            currentDivision,
+            newDivision
+        ];
+
+        var bowler = new Bowler
+        {
+            Id = BowlerId.New()
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = bowler.Id,
+            Bowler = bowler,
+            Division = currentDivision,
+            Squads = [.. new[] {squadId1, squadId2}.Select(s => new SquadRegistration
+            {
+                SquadId = s,
+                Squad = new TournamentSquad { Id = s },
+                RegistrationId = registrationId
+            })],
+            SuperSweeper = false,
+            Average = 200
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        bowler.DateOfBirth = tournament.Start.AddYears(-20);
+        newDivision.MinimumAge = 21;
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = newDivisionId
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.Errors.All(e => e.Type == ErrorType.Validation), Is.True);
+        Assert.That(result.Errors.Any(e => e.Description == "Bowler too young for selected division"), Is.True);
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenBowlerIsTooOldAndNoGenderInclusion()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperId = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+                new () { Id = squadId2 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId }
+            ],
+            Start = new DateOnly(DateTime.Today.Year, DateTime.Today.Month, DateTime.Today.Day)
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var currentDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+
+        var currentDivision = new Division
+        {
+            Id = currentDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+        var newDivision = new Division
+        {
+            Id = newDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+
+        tournament.Divisions =
+        [
+            currentDivision,
+            newDivision
+        ];
+
+        var bowler = new Bowler
+        {
+            Id = BowlerId.New()
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = bowler.Id,
+            Bowler = bowler,
+            Division = currentDivision,
+            Squads = [.. new[] {squadId1, squadId2}.Select(s => new SquadRegistration
+            {
+                SquadId = s,
+                Squad = new TournamentSquad { Id = s },
+                RegistrationId = registrationId
+            })],
+            SuperSweeper = false,
+            Average = 200
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        bowler.DateOfBirth = tournament.Start.AddYears(-20);
+        newDivision.MaximumAge = 19;
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = newDivisionId
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.Errors.All(e => e.Type == ErrorType.Validation), Is.True);
+        Assert.That(result.Errors.Any(e => e.Description == "Bowler too old for selected division"), Is.True);
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenBowlerDoesNotHaveUsbcIdNumberForHandicapDivision()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperId = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+                new () { Id = squadId2 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId }
+            ],
+            Start = new DateOnly(DateTime.Today.Year, DateTime.Today.Month, DateTime.Today.Day)
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var currentDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+
+        var currentDivision = new Division
+        {
+            Id = currentDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+        var newDivision = new Division
+        {
+            Id = newDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+
+        tournament.Divisions =
+        [
+            currentDivision,
+            newDivision
+        ];
+
+        var bowler = new Bowler
+        {
+            Id = BowlerId.New(),
+            USBCId = "123-45678"
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = bowler.Id,
+            Bowler = bowler,
+            Division = currentDivision,
+            Squads = [.. new[] {squadId1, squadId2}.Select(s => new SquadRegistration
+            {
+                SquadId = s,
+                Squad = new TournamentSquad { Id = s },
+                RegistrationId = registrationId
+            })],
+            SuperSweeper = false,
+            Average = 200
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        bowler.USBCId = "";
+        newDivision.HandicapPercentage = .8m;
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = newDivisionId
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.Errors.All(e => e.Type == ErrorType.Validation), Is.True);
+        Assert.That(result.Errors.Any(e => e.Description == "USBC Id is required for Handicap Divisions"), Is.True);
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenBowlerDoesNotHaveGenderInGenderDivision()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperId = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+                new () { Id = squadId2 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId }
+            ],
+            Start = new DateOnly(DateTime.Today.Year, DateTime.Today.Month, DateTime.Today.Day)
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var currentDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+
+        var currentDivision = new Division
+        {
+            Id = currentDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+        var newDivision = new Division
+        {
+            Id = newDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+
+        tournament.Divisions =
+        [
+            currentDivision,
+            newDivision
+        ];
+
+        var bowler = new Bowler
+        {
+            Id = BowlerId.New(),
+            USBCId = "123-45678"
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = bowler.Id,
+            Bowler = bowler,
+            Division = currentDivision,
+            Squads = [.. new[] {squadId1, squadId2}.Select(s => new SquadRegistration
+            {
+                SquadId = s,
+                Squad = new TournamentSquad { Id = s },
+                RegistrationId = registrationId
+            })],
+            SuperSweeper = false,
+            Average = 200
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        bowler.Gender = null;
+        newDivision.Gender = TournamentManager.Models.Gender.Female;
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = newDivisionId
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.Errors.All(e => e.Type == ErrorType.Validation), Is.True);
+        Assert.That(result.Errors.Any(e => e.Description == "Gender is required for selected division"), Is.True);
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnAnError_WhenBowlerIsWrongGenderInGenderDivision()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperId = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+                new () { Id = squadId2 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId }
+            ],
+            Start = new DateOnly(DateTime.Today.Year, DateTime.Today.Month, DateTime.Today.Day)
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var currentDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+
+        var currentDivision = new Division
+        {
+            Id = currentDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+        var newDivision = new Division
+        {
+            Id = newDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+
+        tournament.Divisions =
+        [
+            currentDivision,
+            newDivision
+        ];
+
+        var bowler = new Bowler
+        {
+            Id = BowlerId.New(),
+            USBCId = "123-45678"
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = bowler.Id,
+            Bowler = bowler,
+            Division = currentDivision,
+            Squads = [.. new[] {squadId1, squadId2}.Select(s => new SquadRegistration
+            {
+                SquadId = s,
+                Squad = new TournamentSquad { Id = s },
+                RegistrationId = registrationId
+            })],
+            SuperSweeper = false,
+            Average = 200
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        bowler.Gender = TournamentManager.Models.Gender.Male;
+        newDivision.Gender = TournamentManager.Models.Gender.Female;
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = newDivisionId
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.Errors.All(e => e.Type == ErrorType.Validation), Is.True);
+        Assert.That(result.Errors.Any(e => e.Description == "Invalid gender for selected division"), Is.True);
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldUpdateRegistration_WhenBowlerMeetsDivisionRequirements()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperId = SquadId.New();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+                new () { Id = squadId2 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId }
+            ],
+            Start = new DateOnly(DateTime.Today.Year, DateTime.Today.Month, DateTime.Today.Day)
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var currentDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+
+        var currentDivision = new Division
+        {
+            Id = currentDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+        var newDivision = new Division
+        {
+            Id = newDivisionId,
+            TournamentId = tournament.Id,
+            Tournament = tournament
+        };
+
+        tournament.Divisions =
+        [
+            currentDivision,
+            newDivision
+        ];
+
+        var bowler = new Bowler
+        {
+            Id = BowlerId.New()
+        };
+
+        var registrationId = RegistrationId.New();
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = bowler.Id,
+            Bowler = bowler,
+            Division = currentDivision,
+            Squads = [.. new[] {squadId1, squadId2}.Select(s => new SquadRegistration
+            {
+                SquadId = s,
+                Squad = new TournamentSquad { Id = s },
+                RegistrationId = registrationId
+            })],
+            SuperSweeper = false,
+            Average = 200
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        bowler.Gender = TournamentManager.Models.Gender.Male;
+        bowler.DateOfBirth = tournament.Start.AddYears(-19);
+        bowler.USBCId = "123-45678";
+
+        newDivision.Gender = TournamentManager.Models.Gender.Female;
+        newDivision.MinimumAge = 18;
+        newDivision.MaximumAge = 20;
+        newDivision.MinimumAverage = 150;
+        newDivision.MaximumAverage = 152;
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            DivisionId = newDivisionId,
+            Average = 151
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.False);
+        Assert.That(result.Value, Is.EqualTo(Result.Updated));
+
+        Expression<Func<Registration, bool>> validRegistration =
+            registration => registration.DivisionId == newDivisionId
+                && registration.Average == 151;
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.Is(validRegistration), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldAddPaymentConfirmation_WhenNewPaymentConfirmationIsProvided()
+    {
+        // Arrange
+        var squadId1 = SquadId.New();
+        var sweeperId1 = new SquadId();
+
+        var tournament = new Tournament
+        {
+            Id = TournamentId.New(),
+            Squads =
+            [
+                new () { Id = squadId1 },
+            ],
+            Sweepers =
+            [
+                new () { Id = sweeperId1 }
+            ],
+            Start = new DateOnly(DateTime.Today.Year, DateTime.Today.Month, DateTime.Today.Day)
+        };
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        var registrationId = RegistrationId.New();
+        var existingPayment = new Payment
+        {
+            Id = PaymentId.New(),
+            RegistrationId = registrationId,
+            Amount = 100,
+            CreatedAtUtc = DateTime.UtcNow.AddDays(-4),
+            ConfirmationCode = "12345"
+        };
+        var existingRegistration = new Registration
+        {
+            Id = registrationId,
+            BowlerId = BowlerId.New(),
+            Division = new Division { TournamentId = tournament.Id },
+            Squads = [new SquadRegistration { SquadId = squadId1, Squad = new TournamentSquad { Id = squadId1 }, RegistrationId = registrationId }],
+            SuperSweeper = false,
+            Average = 200,
+            Payments =
+            [
+                existingPayment
+            ]
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(registrationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        var newPayment = new TournamentManager.Models.Payment
+        {
+            Amount = 200,
+            ConfirmationCode = "67890"
+        };
+
+        var command = new UpdateRegistrationCommand
+        {
+            Id = registrationId,
+            Payment = newPayment
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.False);
+        Assert.That(result.Value, Is.EqualTo(Result.Updated));
+
+        Expression<Func<Registration, bool>> validRegistration =
+            registration => registration.Payments.All(p => p.ConfirmationCode == newPayment.ConfirmationCode || p.ConfirmationCode == existingPayment.ConfirmationCode)
+            && registration.Payments.Count == 2
+            && registration.Payments.All(payment => payment.CreatedAtUtc != DateTime.MinValue)
+            && registration.Payments.All(payment => payment.RegistrationId == registrationId);
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.Is(validRegistration), It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/source/tests/BowlingMegabucks.TournamentManager.UnitTests/Registrations/UpdateRegistration/UpdateRegistrationCommandHandlerTests.cs
+++ b/source/tests/BowlingMegabucks.TournamentManager.UnitTests/Registrations/UpdateRegistration/UpdateRegistrationCommandHandlerTests.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+
+namespace BowlingMegabucks.TournamentManager.UnitTests.Registrations.UpdateRegistration;
+
+[TestFixture]
+public sealed class UpdateRegistrationCommandHandlerTests
+{
+    private Mock<TournamentManager.Registrations.IRepository> _mockRegistrationRepository;
+    private Mock<TournamentManager.Scores.IRepository> _mockScoresRepository;
+    private IValidator<TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationRecord> _registrationValidator;
+    private Mock<TournamentManager.Tournaments.IRepository> _mockTournamentRepository;
+    private TournamentManager.Registrations.IPaymentEntityMapper _paymentEntityMapper;
+
+    private TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommandHandler _handler;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRegistrationRepository = new Mock<TournamentManager.Registrations.IRepository>();
+        _mockScoresRepository = new Mock<TournamentManager.Scores.IRepository>();
+        _registrationValidator = new InlineValidator<TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationRecord>();
+        _mockTournamentRepository = new Mock<TournamentManager.Tournaments.IRepository>();
+        _paymentEntityMapper = new TournamentManager.Registrations.PaymentEntityMapper();
+
+        _handler = new TournamentManager.Registrations.UpdateRegistration.UpdateRegistrationCommandHandler(
+            _mockRegistrationRepository.Object,
+            _mockScoresRepository.Object,
+            _mockTournamentRepository.Object,
+            _paymentEntityMapper,
+            _registrationValidator);
+    }
+}


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the registration update flow, error handling, and entity mapping in the registration system. The most significant changes include improvements to the Update Registration endpoint and request/response models, more robust error reporting, and better separation of concerns in the entity mapping layer. Additionally, the logging level for error messages has been adjusted, and some minor improvements and cleanups have been made.

**Update Registration Endpoint and Validation:**

- Refactored the `UpdateRegistrationEndpoint` to use a command handler pattern, returning typed results and improved error handling. The route parameter is now `RegistrationId` instead of `Id`, and the endpoint integrates with the command handler for business logic. [[1]](diffhunk://#diff-c00edcccf053f01198eed9956c59e731349d3b1ee710e2bd3f8aff884852c8ddR4-R15) [[2]](diffhunk://#diff-c00edcccf053f01198eed9956c59e731349d3b1ee710e2bd3f8aff884852c8ddR52-R88)
- Updated the `UpdateRegistrationRequest` and its validator to use `RegistrationId` as the route parameter, ensuring consistency between the request and registration details. [[1]](diffhunk://#diff-d4332423b9f4abe05ea1746e5af9a77e168a997736e63332d9ddd9fea3254df5L11-R15) [[2]](diffhunk://#diff-a4910341eeb3688ecc03706014c91ed0e3e6d12a36bfb42070cc7ac7f4072c1cL11-R11) [[3]](diffhunk://#diff-a4910341eeb3688ecc03706014c91ed0e3e6d12a36bfb42070cc7ac7f4072c1cL21-R22)
- Enhanced the `UpdateRegistrationInput` model to allow nullable fields for partial updates (e.g., `DivisionId`, `Average`, `Payment`), and clarified documentation. [[1]](diffhunk://#diff-25d258712318239c3c0d03a519f7f0f64917c46cc6fb2ba42f049954164251bdR14-R26) [[2]](diffhunk://#diff-25d258712318239c3c0d03a519f7f0f64917c46cc6fb2ba42f049954164251bdL22-R40) [[3]](diffhunk://#diff-25d258712318239c3c0d03a519f7f0f64917c46cc6fb2ba42f049954164251bdL36-R49)
- Removed a validation rule in `CreateRegistrationValidator` that required sweepers to be entered if Super Sweeper is selected, simplifying input requirements.

**Error Handling and Logging:**

- Improved the structure of error details in problem responses, including all metadata from errors in the response payload for better debugging and client feedback.
- Changed logging for registration creation, deletion, and retrieval errors from `Error` to `Information` level to reduce noise in error logs and better align with expected error scenarios. [[1]](diffhunk://#diff-56a505a3d1f25f2f1d538c1f463a8cce4d5cab5ff5044f69f015fc3bd479583fL68-R68) [[2]](diffhunk://#diff-2cd85ee53cb99e653a91c354cebff9c136aee57c06134b298a2d5d777d4c5ee4L69-R69) [[3]](diffhunk://#diff-85b3402d96ab5680db87c38975d1b9d5bf21b082da3645a5e9d1cea01b4f909aL67-R67)

**Entity Mapping and Dependency Injection:**

- Introduced a dedicated `PaymentEntityMapper` and corresponding interface for mapping payment models to entities, improving separation of concerns.
- Refactored `EntityMapper` to use dependency injection for both bowler and payment mappers, and updated registration mapping to use the new payment mapper. [[1]](diffhunk://#diff-5a2b7cb61e836a1d3a45449b763e8d5b03fd33499fef6bc4b49f7867984fd622L7-R16) [[2]](diffhunk://#diff-5a2b7cb61e836a1d3a45449b763e8d5b03fd33499fef6bc4b49f7867984fd622L36-L48)
- Registered the new mappers and validators in the DI container, and set up the command handler and its telemetry decorator for update registration operations. [[1]](diffhunk://#diff-69741a0f26c223a38df780aa66393bddadbceb92cf902a837f63ad33ef71a2d8R19) [[2]](diffhunk://#diff-69741a0f26c223a38df780aa66393bddadbceb92cf902a837f63ad33ef71a2d8R45-R51)

**Database and Model Consistency:**

- Changed the `SquadType` discriminator in the `Squad` entity to use the new `SquadType` enum instead of raw integers, improving code clarity and safety. [[1]](diffhunk://#diff-d4b18ce9066ce30f20d613cee304dc59f348c7fa79b80d6c213c68715340d26bL49-R51) [[2]](diffhunk://#diff-923679bfcf73f6bb1f89d0a252246948c2aad2ca4097728660f01598d6a188e8R1-R8)
- Removed unnecessary `.AsNoTracking()` from a registration repository query to ensure entity tracking as needed.

**Miscellaneous:**

- Added "USBC" to the code spell checker words list for improved developer experience.
- Added missing `using FastEndpoints;` directive for clarity and consistency.

Let me know if you want to discuss any of these changes in more detail!