### PR TITLE
Append Registration

### DIFF
--- a/source/api/Registrations/CreateRegistration/BowlerInput.cs
+++ b/source/api/Registrations/CreateRegistration/BowlerInput.cs
@@ -91,6 +91,6 @@ internal static class BowlerInputExtensions
             DateOfBirth = input.DateOfBirth,
 
             USBCId = input.UsbcId,
-            Gender = Models.Gender.FromName(input.Gender)
+            Gender = input.Gender == "M" ? Models.Gender.Male : Models.Gender.Female
         };
 }

--- a/source/business logic/Models/RegistrationModel.cs
+++ b/source/business logic/Models/RegistrationModel.cs
@@ -102,6 +102,15 @@ public class Registration
         SuperSweeper = registration.SuperSweeper;
     }
 
+    internal void AddSquad(Squad squad)
+        => Squads = Squads.Union(new[] { squad });
+
+    internal void AddSweeper(Sweeper sweeper)
+        => Sweepers = Sweepers.Union(new[] { sweeper });
+
+    internal void AddPayment(Payment payment)
+        => Payments = Payments.Union(new[] { payment });
+
     /// <summary>
     /// Unit Test Constructor
     /// </summary>

--- a/source/business logic/Registrations/AppendRegistration/AppendRegistrationCommand.cs
+++ b/source/business logic/Registrations/AppendRegistration/AppendRegistrationCommand.cs
@@ -2,8 +2,10 @@ using BowlingMegabucks.TournamentManager.Abstractions.Messaging;
 
 namespace BowlingMegabucks.TournamentManager.Registrations.AppendRegistration;
 
+/// <summary>
 /// Command to append to an existing registration.
 /// </summary>
+/// <value></value>
 public record AppendRegistrationCommand
     : ICommand<RegistrationId>
 {

--- a/source/business logic/Registrations/AppendRegistration/AppendRegistrationCommand.cs
+++ b/source/business logic/Registrations/AppendRegistration/AppendRegistrationCommand.cs
@@ -1,11 +1,11 @@
 using BowlingMegabucks.TournamentManager.Abstractions.Messaging;
 
-namespace BowlingMegabucks.TournamentManager.Registrations.CreateRegistration;
+namespace BowlingMegabucks.TournamentManager.Registrations.AppendRegistration;
 
 /// <summary>
 /// Command to create a new registration.
 /// </summary>
-public record CreateRegistrationCommand
+public record AppendRegistrationCommand
     : ICommand<RegistrationId>
 {
     /// <summary>
@@ -40,8 +40,6 @@ public record CreateRegistrationCommand
 
     /// <summary>
     /// Indicates whether the bowler is registering for the super sweeper.
-    /// If null, defaults to false for new registrations
-    /// If registration exists, null mean no change, and a value means to change existing to provided value
     /// </summary>
     public bool? SuperSweeper { get; init; }
     

--- a/source/business logic/Registrations/AppendRegistration/AppendRegistrationCommand.cs
+++ b/source/business logic/Registrations/AppendRegistration/AppendRegistrationCommand.cs
@@ -2,8 +2,7 @@ using BowlingMegabucks.TournamentManager.Abstractions.Messaging;
 
 namespace BowlingMegabucks.TournamentManager.Registrations.AppendRegistration;
 
-/// <summary>
-/// Command to create a new registration.
+/// Command to append to an existing registration.
 /// </summary>
 public record AppendRegistrationCommand
     : ICommand<RegistrationId>

--- a/source/business logic/Registrations/AppendRegistration/AppendRegistrationCommandHandler.cs
+++ b/source/business logic/Registrations/AppendRegistration/AppendRegistrationCommandHandler.cs
@@ -1,0 +1,126 @@
+using BowlingMegabucks.TournamentManager.Abstractions.Messaging;
+using ErrorOr;
+using FluentValidation;
+
+namespace BowlingMegabucks.TournamentManager.Registrations.AppendRegistration;
+
+internal sealed class AppendRegistrationCommandHandler
+    : ICommandHandler<AppendRegistrationCommand, RegistrationId>
+{
+    private readonly IRepository _registrationRepository;
+    private readonly Divisions.IRepository _divisionRepository;
+    private readonly Squads.IRepository _squadRepository;
+    private readonly Sweepers.IRepository _sweeperRepository;
+    private readonly IValidator<Models.Registration> _registrationValidator;
+    private readonly Bowlers.IEntityMapper _bowlerEntityMapper;
+    private readonly IPaymentEntityMapper _paymentEntityMapper;
+
+    public AppendRegistrationCommandHandler(IRepository registrationRepository,
+                                            Divisions.IRepository divisionRepository,
+                                            Squads.IRepository squadRepository,
+                                            Sweepers.IRepository sweeperRepository,
+                                            IValidator<Models.Registration> registrationValidator,
+                                            Bowlers.IEntityMapper bowlerEntityMapper,
+                                            IPaymentEntityMapper paymentEntityMapper)
+    {
+        _registrationRepository = registrationRepository;
+        _registrationValidator = registrationValidator;
+        _divisionRepository = divisionRepository;
+        _paymentEntityMapper = paymentEntityMapper;
+        _squadRepository = squadRepository;
+        _sweeperRepository = sweeperRepository;
+        _bowlerEntityMapper = bowlerEntityMapper;
+    }
+
+    public async Task<ErrorOr<RegistrationId>> HandleAsync(AppendRegistrationCommand command, CancellationToken cancellationToken)
+    {
+        var existingRegistration = await _registrationRepository.RetrieveAsync(command.Bowler.USBCId, command.TournamentId, cancellationToken);
+
+        if (existingRegistration is null)
+        {
+            return Error.Unexpected("Registration.NotFound", "The specified registration does not exist.");
+        }
+
+        var registrationModel = new Models.Registration(existingRegistration)
+        {
+            Bowler = command.Bowler,
+            Average = command.Average ?? existingRegistration.Average,
+            SuperSweeper = command.SuperSweeper ?? existingRegistration.SuperSweeper
+        };
+
+        if (existingRegistration.DivisionId != command.DivisionId)
+        {
+            var division = await _divisionRepository.RetrieveAsync(command.DivisionId, cancellationToken);
+            if (division is null)
+            {
+                return Error.NotFound("Division.NotFound", "The specified division does not exist.");
+            }
+
+            registrationModel.Division = new Models.Division(division);
+        }
+
+        if (command.Squads.Any())
+        {
+            //if squads on the command exist on the current registration, return a validation error
+            var existingSquadIds = existingRegistration.Squads.Select(s => s.SquadId).ToHashSet();
+            var commandSquadIds = command.Squads.ToHashSet();
+
+            if (existingSquadIds.Overlaps(commandSquadIds))
+            {
+                return Error.Validation("Squad.Conflict", "The specified squads are already registered.");
+            }
+
+            var squads = (await _squadRepository.RetrieveAsync(command.Squads, cancellationToken)).Select(squad => new Models.Squad(squad));
+            foreach (var squad in squads)
+            {
+                registrationModel.AddSquad(squad);
+            }
+        }
+
+        if (command.Sweepers.Any())
+        {
+            //if sweepers on the command exist on the current registration, return a validation error
+            var existingSweeperIds = existingRegistration.Squads.Select(s => s.SquadId).ToHashSet();
+            var commandSweeperIds = command.Sweepers.ToHashSet();
+
+            if (existingSweeperIds.Overlaps(commandSweeperIds))
+            {
+                return Error.Validation("Sweeper.Conflict", "The specified sweepers are already registered.");
+            }
+
+            var sweepers = (await _sweeperRepository.RetrieveAsync(command.Sweepers, cancellationToken)).Select(sweeper => new Models.Sweeper(sweeper));
+            foreach (var sweeper in sweepers)
+            {
+                registrationModel.AddSweeper(sweeper);
+            }
+        }
+
+        var validationResult = await _registrationValidator.ValidateAsync(registrationModel, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            return validationResult.Errors.Select(e => Error.Validation(e.ErrorCode, e.ErrorMessage)).ToList();
+        }
+
+        Database.Entities.Payment? paymentEntity = null;
+        if (command.Payment is not null)
+        {
+            command.Payment.CreatedAtUtc = DateTime.UtcNow;
+            registrationModel.AddPayment(command.Payment);
+            paymentEntity = _paymentEntityMapper.Execute(command.Payment);
+        }
+
+        var bowlerEntity = _bowlerEntityMapper.Execute(command.Bowler);
+        await _registrationRepository.UpdateAsync(
+            existingRegistration,
+            bowlerEntity,
+            command.DivisionId,
+            registrationModel.Average,
+            command.Squads,
+            command.Sweepers,
+            command.SuperSweeper,
+            paymentEntity,
+            cancellationToken);
+
+        return existingRegistration.Id;
+    }
+}

--- a/source/business logic/Registrations/AppendRegistration/AppendRegistrationCommandHandlerTelemetryDecorator.cs
+++ b/source/business logic/Registrations/AppendRegistration/AppendRegistrationCommandHandlerTelemetryDecorator.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics;
+using BowlingMegabucks.TournamentManager.Abstractions.Messaging;
+using ErrorOr;
+using Microsoft.Extensions.Logging;
+
+namespace BowlingMegabucks.TournamentManager.Registrations.AppendRegistration;
+
+internal sealed class AppendRegistrationCommandHandlerTelemetryDecorator
+    : ICommandHandler<AppendRegistrationCommand, RegistrationId>
+{
+    private readonly ICommandHandler<AppendRegistrationCommand, RegistrationId> _innerHandler;
+    private readonly ILogger<AppendRegistrationCommandHandlerTelemetryDecorator> _logger;
+
+    public AppendRegistrationCommandHandlerTelemetryDecorator(ICommandHandler<AppendRegistrationCommand, RegistrationId> innerHandler, ILogger<AppendRegistrationCommandHandlerTelemetryDecorator> logger)
+    {
+        _innerHandler = innerHandler;
+        _logger = logger;
+    }
+
+    public async Task<ErrorOr<RegistrationId>> HandleAsync(AppendRegistrationCommand command, CancellationToken cancellationToken)
+    {
+        using var activity = RegistrationsTelemetry._activity.StartActivity("Append Registration", ActivityKind.Internal);
+
+        _logger.AppendingRegistration(command.Bowler.USBCId, command.TournamentId);
+
+        try
+        {
+            activity?.SetTag("tournament.id", command.TournamentId.Value);
+            activity?.SetTag("bowler.usbcId", command.Bowler.USBCId);
+
+            var result = await _innerHandler.HandleAsync(command, cancellationToken);
+
+            if (result.IsError)
+            {
+                _logger.ErrorAppendingRegistration(result.Errors);
+
+                activity?.SetStatus(ActivityStatusCode.Error);
+                activity?.SetTag("error", true);
+                activity?.SetTag("error.message", string.Join(", ", result.Errors.Select(e => e.Description)));
+
+                return result;
+            }
+
+            _logger.RegistrationAppended(result.Value);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.ErrorAppendingRegistration(ex);
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+            activity?.SetTag("exception", ex.ToString());
+
+            return Error.Failure("AppendRegistrationCommandHandler.Exception", ex.Message);
+        }
+        finally
+        {
+            _logger.ExecutedAppendRegistration(command.Bowler.USBCId, command.TournamentId);
+        }
+    }
+}
+
+internal static partial class AppendRegistrationLogMessages
+{
+    [LoggerMessage(LogLevel.Information, "Appending registration for bowler with UsbcId {UsbcId} in tournament {TournamentId}")]
+    public static partial void AppendingRegistration(this ILogger logger, string usbcId, TournamentId tournamentId);
+
+    [LoggerMessage(LogLevel.Information, "Error appending registration: {@Errors}")]
+    public static partial void ErrorAppendingRegistration(this ILogger logger, IEnumerable<Error> errors);
+
+    [LoggerMessage(LogLevel.Error, "Exception appending registration")]
+    public static partial void ErrorAppendingRegistration(this ILogger logger, Exception ex);
+
+    [LoggerMessage(LogLevel.Information, "Registration appended successfully: {RegistrationId}")]
+    public static partial void RegistrationAppended(this ILogger logger, RegistrationId registrationId);
+
+    [LoggerMessage(LogLevel.Information, "Executed append registration for bowler {UsbcId} in tournament {TournamentId}")]
+    public static partial void ExecutedAppendRegistration(this ILogger logger, string usbcId, TournamentId tournamentId);
+}

--- a/source/business logic/Registrations/CreateRegistration/CreateRegistrationCommandHandler.cs
+++ b/source/business logic/Registrations/CreateRegistration/CreateRegistrationCommandHandler.cs
@@ -80,7 +80,7 @@ internal sealed class CreateRegistrationCommandHandler
 
             Squads = command.Squads.Select(squadId => new Squad { Id = squadId }).ToList(),
             Sweepers = command.Sweepers.Select(sweeperId => new Sweeper { Id = sweeperId }).ToList(),
-            SuperSweeper = command.SuperSweeper,
+            SuperSweeper = command.SuperSweeper ?? false,
             Payments = command.Payment is not null ? [command.Payment] : [],
 
             Average = command.Average

--- a/source/business logic/Registrations/RegistrationExtensions.cs
+++ b/source/business logic/Registrations/RegistrationExtensions.cs
@@ -50,6 +50,10 @@ internal static class RegistrationExtensions
                 provider.GetRequiredService<ILogger<UpdateRegistration.UpdateRegistrationCommandHandlerTelemetryDecorator>>()));
 
         services.AddTransient<AppendRegistration.AppendRegistrationCommandHandler>();
+        services.AddTransient<ICommandHandler<AppendRegistration.AppendRegistrationCommand, RegistrationId>>(provider =>
+            new AppendRegistration.AppendRegistrationCommandHandlerTelemetryDecorator(
+                provider.GetRequiredService<AppendRegistration.AppendRegistrationCommandHandler>(),
+                provider.GetRequiredService<ILogger<AppendRegistration.AppendRegistrationCommandHandlerTelemetryDecorator>>()));
 
         services.AddSingleton<IValidator<Update.UpdateRegistrationModel>, Update.Validator>();
         services.AddTransient<Update.IBusinessLogic, Update.BusinessLogic>();

--- a/source/business logic/Registrations/RegistrationExtensions.cs
+++ b/source/business logic/Registrations/RegistrationExtensions.cs
@@ -49,6 +49,8 @@ internal static class RegistrationExtensions
                 provider.GetRequiredService<UpdateRegistration.UpdateRegistrationCommandHandler>(),
                 provider.GetRequiredService<ILogger<UpdateRegistration.UpdateRegistrationCommandHandlerTelemetryDecorator>>()));
 
+        services.AddTransient<AppendRegistration.AppendRegistrationCommandHandler>();
+
         services.AddSingleton<IValidator<Update.UpdateRegistrationModel>, Update.Validator>();
         services.AddTransient<Update.IBusinessLogic, Update.BusinessLogic>();
         services.AddTransient<Update.IDataLayer, Update.DataLayer>();

--- a/source/business logic/Squads/SquadsRepository.cs
+++ b/source/business logic/Squads/SquadsRepository.cs
@@ -3,7 +3,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BowlingMegabucks.TournamentManager.Squads;
 
-internal class Repository : IRepository
+internal class Repository
+    : IRepository
 {
     private readonly Database.IDataContext _dataContext;
 
@@ -25,6 +26,9 @@ internal class Repository : IRepository
 
     public async Task<Database.Entities.TournamentSquad> RetrieveAsync(SquadId id, CancellationToken cancellationToken)
         => await _dataContext.Squads.AsNoTracking().FirstAsync(squad => squad.Id == id, cancellationToken).ConfigureAwait(false);
+
+    public async Task<IEnumerable<Database.Entities.TournamentSquad>> RetrieveAsync(IEnumerable<SquadId> ids, CancellationToken cancellationToken)
+        => await _dataContext.Squads.AsNoTracking().Where(squad => ids.Contains(squad.Id)).ToListAsync(cancellationToken);
 
     public async Task CompleteAsync(SquadId id, CancellationToken cancellationToken)
     {
@@ -62,6 +66,8 @@ internal interface IRepository
     IQueryable<Database.Entities.TournamentSquad> Retrieve(TournamentId tournamentId);
 
     Task<Database.Entities.TournamentSquad> RetrieveAsync(SquadId id, CancellationToken cancellationToken);
+
+    Task<IEnumerable<Database.Entities.TournamentSquad>> RetrieveAsync(IEnumerable<SquadId> ids, CancellationToken cancellationToken);
 
     Task CompleteAsync(SquadId id, CancellationToken cancellationToken);
 }

--- a/source/business logic/Sweepers/SweepersRepository.cs
+++ b/source/business logic/Sweepers/SweepersRepository.cs
@@ -25,6 +25,11 @@ internal class Repository : IRepository
     public async Task<Database.Entities.SweeperSquad> RetrieveAsync(SquadId id, CancellationToken cancellationToken)
         => await _dataContext.Sweepers.AsNoTracking().FirstAsync(sweeper => sweeper.Id == id, cancellationToken).ConfigureAwait(false);
 
+    public async Task<IEnumerable<Database.Entities.SweeperSquad>> RetrieveAsync(IEnumerable<SquadId> ids, CancellationToken cancellationToken)
+        => await _dataContext.Sweepers
+            .Include(sweeper => sweeper.Divisions).AsNoTrackingWithIdentityResolution()
+            .Where(sweeper => ids.Contains(sweeper.Id)).ToListAsync(cancellationToken);
+
     public async Task CompleteAsync(SquadId id, CancellationToken cancellationToken)
     {
         var sweeper = await _dataContext.Sweepers.FirstAsync(sweeper => sweeper.Id == id, cancellationToken).ConfigureAwait(false);
@@ -44,6 +49,8 @@ internal interface IRepository
     IQueryable<Database.Entities.SweeperSquad> Retrieve(TournamentId tournamentId);
 
     Task<Database.Entities.SweeperSquad> RetrieveAsync(SquadId id, CancellationToken cancellationToken);
+
+    Task<IEnumerable<Database.Entities.SweeperSquad>> RetrieveAsync(IEnumerable<SquadId> ids, CancellationToken cancellationToken);
 
     Task CompleteAsync(SquadId id, CancellationToken cancellationToken);
 

--- a/source/presentation/BowlingMegabucks.TournamentManager.Presentation.csproj
+++ b/source/presentation/BowlingMegabucks.TournamentManager.Presentation.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>BowlingMegabucks.TournamentManager</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/presentation/Properties/AssemblyInfo.cs
+++ b/source/presentation/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 
+[assembly: System.Reflection.AssemblyVersion("1.0.0.0")]
+
 [assembly: InternalsVisibleTo("BowlingMegabucks.TournamentManager.UnitTests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/source/tests/BowlingMegabucks.TournamentManager.IntegrationTests/Registrations/AppendRegistrationTests.cs
+++ b/source/tests/BowlingMegabucks.TournamentManager.IntegrationTests/Registrations/AppendRegistrationTests.cs
@@ -1,0 +1,243 @@
+using System.Net;
+using System.Net.Http.Json;
+using BowlingMegabucks.TournamentManager.Api.Registrations.CreateRegistration;
+using BowlingMegabucks.TournamentManager.Database.Entities;
+using BowlingMegabucks.TournamentManager.IntegrationTests.Bowlers;
+using BowlingMegabucks.TournamentManager.IntegrationTests.Divisions;
+using BowlingMegabucks.TournamentManager.IntegrationTests.Infrastructure;
+using BowlingMegabucks.TournamentManager.IntegrationTests.Squads;
+using BowlingMegabucks.TournamentManager.IntegrationTests.Sweepers;
+using BowlingMegabucks.TournamentManager.IntegrationTests.Tournaments;
+using BowlingMegabucks.TournamentManager.Registrations;
+using Microsoft.EntityFrameworkCore;
+
+namespace BowlingMegabucks.TournamentManager.IntegrationTests.Registrations;
+
+public sealed class AppendRegistrationTests
+    : IntegrationTestFixture
+{
+    public AppendRegistrationTests(TournamentManagerWebAppFactory factory)
+        : base(factory)
+    { }
+
+    [Fact]
+    public async Task AppendRegistration_ShouldReturn401_WhenNotAuthenticated()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+
+        var tournament = TournamentEntityFactory.Bogus();
+        var bowler = BowlerEntityFactory.Bogus();
+        var division = DivisionEntityFactory.Create(tournament.Id);
+        var squads = SquadEntityFactory.Bogus(2, tournament.Id).ToList();
+        var sweepers = SweeperEntityFactory.Bogus(2, tournament.Id);
+
+        var existingRegistration = RegistrationEntityFactory.Create(
+            division: division,
+            bowler: bowler,
+            squadIds: [squads[0].Id],
+            sweeperIds: [],
+            superSweeper: false,
+            average: 200,
+            payment: PaymentEntityFactory.Bogus()
+        );
+
+        _dbContext.Tournaments.Add(tournament);
+        _dbContext.Bowlers.Add(bowler);
+        _dbContext.Divisions.Add(division);
+        _dbContext.Squads.AddRange(squads);
+        _dbContext.Sweepers.AddRange(sweepers);
+        _dbContext.Registrations.Add(existingRegistration);
+
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var bowlerInput = BowlerInputFactory.Create(usbcId: bowler.USBCId);
+        var registrationInput = new RegistrationInput
+        {
+            Bowler = bowlerInput,
+            TournamentId = tournament.Id,
+            DivisionId = division.Id,
+            Squads = [squads[1].Id],
+            Sweepers = [],
+            SuperSweeper = false,
+            Average = 201
+        };
+
+        var createRegistrationRequest = new CreateRegistrationRequest
+        {
+            Registration = registrationInput
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "v1/registrations")
+        {
+            Content = JsonContent.Create(createRegistrationRequest)
+        };
+
+        // Act
+        var response = await CreateClient().SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task AppendRegistration_ShouldReturn400_WhenInvalidDataIsProvided()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+
+        var tournament = TournamentEntityFactory.Bogus();
+        var bowler = BowlerEntityFactory.Bogus();
+        var division = DivisionEntityFactory.Create(tournament.Id);
+        var squads = SquadEntityFactory.Bogus(2, tournament.Id).ToList();
+        var sweepers = SweeperEntityFactory.Bogus(2, tournament.Id);
+
+        var existingRegistration = RegistrationEntityFactory.Create(
+            division: division,
+            bowler: bowler,
+            squadIds: [squads[0].Id],
+            sweeperIds: [],
+            superSweeper: false,
+            average: 200,
+            payment: PaymentEntityFactory.Bogus()
+        );
+
+        _dbContext.Tournaments.Add(tournament);
+        _dbContext.Bowlers.Add(bowler);
+        _dbContext.Divisions.Add(division);
+        _dbContext.Squads.AddRange(squads);
+        _dbContext.Sweepers.AddRange(sweepers);
+        _dbContext.Registrations.Add(existingRegistration);
+
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var bowlerInput = BowlerInputFactory.Create(usbcId: bowler.USBCId);
+        var registrationInput = new RegistrationInput
+        {
+            Bowler = bowlerInput,
+            TournamentId = tournament.Id,
+            DivisionId = division.Id,
+            Squads = [squads[0].Id, squads[1].Id], // already registered for squads[0]
+            Sweepers = [],
+            SuperSweeper = false,
+            Average = 201
+        };
+
+        var createRegistrationRequest = new CreateRegistrationRequest
+        {
+            Registration = registrationInput
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "v1/registrations")
+        {
+            Content = JsonContent.Create(createRegistrationRequest)
+        };
+
+        // Act
+        var response = await CreateAuthenticatedClient().SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var verifyRegistration = await _dbContext.Registrations
+            .Include(registration => registration.Squads)
+            .Include(registration => registration.Bowler)
+            .AsNoTrackingWithIdentityResolution()
+            .SingleAsync(registration => registration.Id == existingRegistration.Id, TestContext.Current.CancellationToken);
+
+        verifyRegistration.Squads.Should().ContainSingle();
+        verifyRegistration.Bowler.FirstName.Should().Be(bowler.FirstName);
+        verifyRegistration.Bowler.LastName.Should().Be(bowler.LastName);
+        verifyRegistration.Average.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task AppendRegistration_ShouldReturn201_WhenDataIsValid()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+
+        var tournament = TournamentEntityFactory.Bogus();
+        var division = DivisionEntityFactory.Create(tournament.Id);
+        var squads = SquadEntityFactory.Bogus(3, tournament.Id).ToList();
+        var sweepers = SweeperEntityFactory.Bogus(3, tournament.Id).ToList();
+        var bowler = BowlerEntityFactory.Bogus();
+
+        var registration = RegistrationEntityFactory.Create(
+            bowler: bowler,
+            division: division,
+            squadIds: squads.Select(s => s.Id).Take(2),
+            sweeperIds: sweepers.Select(s => s.Id).Take(2),
+            superSweeper: false,
+            average: 199);
+
+        var payment = PaymentEntityFactory.Bogus(1, registration.Id).Single();
+        registration.Payments.Clear();
+        registration.Payments.Add(payment);
+
+        var newDivision = new Division
+        {
+            Id = DivisionId.New(),
+            TournamentId = tournament.Id,
+            HandicapPercentage = .9m,
+            HandicapBase = 210,
+            MaximumHandicapPerGame = 25
+        };
+
+        _dbContext.Tournaments.Add(tournament);
+        _dbContext.Divisions.AddRange(division, newDivision);
+        _dbContext.Squads.AddRange(squads);
+        _dbContext.Sweepers.AddRange(sweepers);
+        _dbContext.Bowlers.Add(bowler);
+        _dbContext.Registrations.Add(registration);
+
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var newRegistration = new RegistrationInput
+        {
+            Bowler = bowler!.ToInput(),
+            TournamentId = tournament.Id,
+            DivisionId = newDivision.Id,
+            Squads = [squads[2].Id],
+            Sweepers = [sweepers[2].Id],
+            SuperSweeper = true,
+            Average = 200
+        };
+
+        var createRegistrationRequest = new CreateRegistrationRequest
+        {
+            Registration = newRegistration
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "v1/registrations")
+        {
+            Content = JsonContent.Create(createRegistrationRequest)
+        };
+
+        // Act
+        var response = await CreateAuthenticatedClient().SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull();
+
+        var registrationResponse = await response.Content.ReadFromJsonAsync<CreateRegistrationResponse>(TestContext.Current.CancellationToken);
+        registrationResponse.Should().NotBeNull();
+        registrationResponse!.RegistrationId.Should().NotBe(RegistrationId.Empty);
+
+        response.Headers.Location!.ToString().Should().Be($"http://localhost/v1/registrations/{registrationResponse.RegistrationId}");
+        registrationResponse.RegistrationId.Should().Be(registration.Id);
+
+        var verifyRegistration = await _dbContext.Registrations
+            .Include(registration => registration.Squads)
+            .Include(registration => registration.Bowler)
+            .AsNoTrackingWithIdentityResolution()
+            .SingleAsync(r => r.Id == registration.Id, TestContext.Current.CancellationToken);
+
+        verifyRegistration.Squads.Should().HaveCount(6);
+        verifyRegistration.Bowler.FirstName.Should().Be(bowler.FirstName);
+        verifyRegistration.Bowler.LastName.Should().Be(bowler.LastName);
+        verifyRegistration.Average.Should().Be(200);
+        verifyRegistration.SuperSweeper.Should().BeTrue();
+    }
+}

--- a/source/tests/BowlingMegabucks.TournamentManager.IntegrationTests/Registrations/BowlerInputFactory.cs
+++ b/source/tests/BowlingMegabucks.TournamentManager.IntegrationTests/Registrations/BowlerInputFactory.cs
@@ -40,51 +40,75 @@ internal static class BowlerInputFactory
                 PhoneNumber = phoneNumber ?? "555-555-5555",
                 UsbcId = usbcId ?? "12345-67890",
                 DateOfBirth = dateOfBirth ?? new DateOnly(2000, 1, 1),
-                Gender = gender?.Name ?? "Male"
+                Gender = gender?.Name.Substring(0,1) ?? "M"
             };
 }
 
 internal sealed class BowlerInputFaker
         : Faker<BowlerInput>
+{
+    public BowlerInputFaker()
+        : this(DateTime.UtcNow.GetHashCode())
+    { }
+
+    public BowlerInputFaker(int seed)
     {
-        public BowlerInputFaker()
-            : this(DateTime.UtcNow.GetHashCode())
-        { }
+        UseSeed(seed);
 
-        public BowlerInputFaker(int seed)
+        RuleFor(bowler => bowler.FirstName, faker => faker.Name.FirstName());
+        RuleFor(bowler => bowler.MiddleInitial, faker => faker.Random.Char().ToString().OrNull(faker, 0.6f));
+        RuleFor(bowler => bowler.LastName, faker => faker.Name.LastName());
+        RuleFor(bowler => bowler.Suffix, faker => faker.Name.Suffix().OrNull(faker, 0.7f));
+
+        RuleFor(bowler => bowler.Address, faker => new AddressInput
         {
-            UseSeed(seed);
+            Street = faker.Person.Address.Street,
+            City = faker.Person.Address.City,
+            State = faker.Person.Address.State,
+            ZipCode = faker.Person.Address.ZipCode
+        });
+        RuleFor(bowler => bowler.PhoneNumber, faker => faker.Phone.PhoneNumber("###-###-####"));
+        RuleFor(bowler => bowler.Email, faker => faker.Person.Email);
+        RuleFor(bowler => bowler.DateOfBirth, faker => DateOnly.FromDateTime(faker.Person.DateOfBirth));
+        RuleFor(bowler => bowler.Gender, faker => faker.Person.Gender == Bogus.DataSets.Name.Gender.Male
+            ? Models.Gender.Male.Name
+            : Models.Gender.Female.Name);
 
-            RuleFor(bowler => bowler.FirstName, faker => faker.Name.FirstName());
-            RuleFor(bowler => bowler.MiddleInitial, faker => faker.Random.Char().ToString().OrNull(faker, 0.6f));
-            RuleFor(bowler => bowler.LastName, faker => faker.Name.LastName());
-            RuleFor(bowler => bowler.Suffix, faker => faker.Name.Suffix().OrNull(faker, 0.7f));
+        RuleFor(bowler => bowler.UsbcId, f =>
+        {
+            // Generate part 1: 1 to 5 digits
+            var part1Length = f.Random.Int(2, 5);
+            var part1 = f.Random.Number((int)Math.Pow(10, part1Length - 1), (int)Math.Pow(10, part1Length) - 1).ToString(CultureInfo.CurrentCulture);
 
-            RuleFor(bowler => bowler.Address, faker => new AddressInput
-            {
-                Street = faker.Person.Address.Street,
-                City = faker.Person.Address.City,
-                State = faker.Person.Address.State,
-                ZipCode = faker.Person.Address.ZipCode
-            });
-            RuleFor(bowler => bowler.PhoneNumber, faker => faker.Phone.PhoneNumber("###-###-####"));
-            RuleFor(bowler => bowler.Email, faker => faker.Person.Email);
-            RuleFor(bowler => bowler.DateOfBirth, faker => DateOnly.FromDateTime(faker.Person.DateOfBirth));
-            RuleFor(bowler => bowler.Gender, faker => faker.Person.Gender == Bogus.DataSets.Name.Gender.Male
-                ? Models.Gender.Male.Name
-                : Models.Gender.Female.Name);
+            // Generate part 2: 1 to 7 digits
+            var part2Length = f.Random.Int(3, 7);
+            var part2 = f.Random.Number((int)Math.Pow(10, part2Length - 1), (int)Math.Pow(10, part2Length) - 1).ToString(CultureInfo.CurrentCulture);
 
-            RuleFor(bowler => bowler.UsbcId, f =>
-            {
-                // Generate part 1: 1 to 5 digits
-                var part1Length = f.Random.Int(2, 5);
-                var part1 = f.Random.Number((int)Math.Pow(10, part1Length - 1), (int)Math.Pow(10, part1Length) - 1).ToString(CultureInfo.CurrentCulture);
-
-                // Generate part 2: 1 to 7 digits
-                var part2Length = f.Random.Int(3, 7);
-                var part2 = f.Random.Number((int)Math.Pow(10, part2Length - 1), (int)Math.Pow(10, part2Length) - 1).ToString(CultureInfo.CurrentCulture);
-
-                return $"{part1}-{part2}";
-            });
-        }
+            return $"{part1}-{part2}";
+        });
     }
+}
+
+internal static class BowlerInputExtensions
+{
+    public static BowlerInput ToInput(this Database.Entities.Bowler bowler)
+        => new()
+        {
+            FirstName = bowler.FirstName,
+            MiddleInitial = bowler.MiddleInitial,
+            LastName = bowler.LastName,
+            Suffix = bowler.Suffix,
+            Address = new AddressInput
+            {
+                Street = bowler.StreetAddress,
+                City = bowler.CityAddress,
+                State = bowler.StateAddress,
+                ZipCode = bowler.ZipCode
+            },
+            Email = bowler.EmailAddress,
+            PhoneNumber = bowler.PhoneNumber,
+            UsbcId = bowler.USBCId,
+            DateOfBirth = bowler.DateOfBirth,
+            Gender = bowler.Gender?.Name.Substring(0, 1)
+        };
+}

--- a/source/tests/BowlingMegabucks.TournamentManager.UnitTests/Registrations/AppendRegistration/AppendRegistrationCommandHandlerTests.cs
+++ b/source/tests/BowlingMegabucks.TournamentManager.UnitTests/Registrations/AppendRegistration/AppendRegistrationCommandHandlerTests.cs
@@ -9,6 +9,7 @@ namespace BowlingMegabucks.TournamentManager.UnitTests.Registrations.AppendRegis
 public sealed class AppendRegistrationCommandHandlerTests
 {
     private Mock<TournamentManager.Registrations.IRepository> _mockRegistrationRepository;
+    private Mock<TournamentManager.Tournaments.IRepository> _mockTournamentRepository;
     private Mock<TournamentManager.Divisions.IRepository> _mockDivisionRepository;
     private Mock<TournamentManager.Squads.IRepository> _mockSquadRepository;
     private Mock<TournamentManager.Sweepers.IRepository> _mockSweeperRepository;
@@ -22,6 +23,7 @@ public sealed class AppendRegistrationCommandHandlerTests
     public void SetUp()
     {
         _mockRegistrationRepository = new Mock<TournamentManager.Registrations.IRepository>();
+        _mockTournamentRepository = new Mock<TournamentManager.Tournaments.IRepository>();
         _mockDivisionRepository = new Mock<TournamentManager.Divisions.IRepository>();
         _mockSquadRepository = new Mock<TournamentManager.Squads.IRepository>();
         _mockSweeperRepository = new Mock<TournamentManager.Sweepers.IRepository>();
@@ -31,6 +33,7 @@ public sealed class AppendRegistrationCommandHandlerTests
 
         _handler = new AppendRegistrationCommandHandler(
             _mockRegistrationRepository.Object,
+            _mockTournamentRepository.Object,
             _mockDivisionRepository.Object,
             _mockSquadRepository.Object,
             _mockSweeperRepository.Object,
@@ -90,8 +93,22 @@ public sealed class AppendRegistrationCommandHandlerTests
             Payments = []
         };
 
+        var tournament = new TournamentManager.Database.Entities.Tournament
+        {
+            Id = TournamentId.New(),
+            Start = new DateOnly(2024, 1, 1),
+            Sweepers =
+            [
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] },
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] }
+            ]
+        };
+
         _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
 
         _mockDivisionRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<DivisionId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Division)null);
@@ -136,12 +153,26 @@ public sealed class AppendRegistrationCommandHandlerTests
             Bowler = new Bowler { USBCId = "12345" },
             DivisionId = divisionId, // Set the DivisionId property directly
             Division = new Division { Id = divisionId },
-            Squads = new List<SquadRegistration>(),
-            Payments = new List<Payment>()
+            Squads = [],
+            Payments = []
+        };
+
+        var tournament = new TournamentManager.Database.Entities.Tournament
+        {
+            Id = TournamentId.New(),
+            Start = new DateOnly(2024, 1, 1),
+            Sweepers =
+            [
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] },
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] }
+            ]
         };
 
         _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
 
         _mockRegistrationValidator.Setup(validator => validator.ValidateAsync(It.IsAny<TournamentManager.Models.Registration>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new FluentValidation.Results.ValidationResult());
@@ -176,17 +207,31 @@ public sealed class AppendRegistrationCommandHandlerTests
             Bowler = new Bowler { USBCId = "12345" },
             DivisionId = divisionId, // Use same division to avoid division lookup
             Division = new Division { Id = divisionId },
-            Squads = new List<SquadRegistration>
-            {
+            Squads =
+            [
                 new() { SquadId = existingSquadId1 },
                 new() { SquadId = existingSquadId2 },
                 new() { SquadId = overlappingSquadId }
-            },
+            ],
             Payments = []
+        };
+
+        var tournament = new TournamentManager.Database.Entities.Tournament
+        {
+            Id = TournamentId.New(),
+            Start = new DateOnly(2024, 1, 1),
+            Sweepers =
+            [
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] },
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] }
+            ]
         };
 
         _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
 
         var command = new AppendRegistrationCommand
         {
@@ -231,17 +276,31 @@ public sealed class AppendRegistrationCommandHandlerTests
             Bowler = new Bowler { USBCId = "12345" },
             DivisionId = divisionId, // Use same division to avoid division lookup
             Division = new Division { Id = divisionId },
-            Squads = new List<SquadRegistration>
-            {
+            Squads =
+            [
                 new() { SquadId = existingSweeperSquadId1 },
                 new() { SquadId = existingSweeperSquadId2 },
                 new() { SquadId = overlappingSweeperSquadId }
-            },
+            ],
             Payments = []
+        };
+
+        var tournament = new TournamentManager.Database.Entities.Tournament
+        {
+            Id = TournamentId.New(),
+            Start = new DateOnly(2024, 1, 1),
+            Sweepers =
+            [
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] },
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] }
+            ]
         };
 
         _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
 
         var command = new AppendRegistrationCommand
         {
@@ -289,8 +348,22 @@ public sealed class AppendRegistrationCommandHandlerTests
             Payments = []
         };
 
+        var tournament = new TournamentManager.Database.Entities.Tournament
+        {
+            Id = TournamentId.New(),
+            Start = new DateOnly(2024, 1, 1),
+            Sweepers =
+            [
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] },
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] }
+            ]
+        };
+
         _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
 
         // Setup validation to fail with multiple errors
         var validationResult = new FluentValidation.Results.ValidationResult();
@@ -372,6 +445,18 @@ public sealed class AppendRegistrationCommandHandlerTests
             Payments = []
         };
 
+        var tournament = new TournamentManager.Database.Entities.Tournament
+        {
+            Id = TournamentId.New(),
+            Start = new DateOnly(2024, 1, 15),
+            Sweepers =
+            [
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] },
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] },
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] }
+            ]
+        };
+
         var newDivision = new Division { Id = newDivisionId, Name = "New Division" };
         var newSquad1 = new TournamentSquad { Id = newSquadId1, Tournament = new Tournament() };
         var newSquad2 = new TournamentSquad { Id = newSquadId2, Tournament = new Tournament() };
@@ -380,6 +465,9 @@ public sealed class AppendRegistrationCommandHandlerTests
 
         _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
 
         _mockDivisionRepository.Setup(repo => repo.RetrieveAsync(newDivisionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(newDivision);
@@ -416,9 +504,12 @@ public sealed class AppendRegistrationCommandHandlerTests
                 reg.Average == 180 &&
                 reg.SuperSweeper == true &&
                 reg.Squads.Count() == 2 &&
-                reg.Sweepers.Count() == 2),
+                reg.Sweepers.Count() == 2 &&
+                reg.TournamentStartDate == new DateOnly(2024, 1, 15) &&
+                reg.TournamentSweeperCount == 3),
             It.IsAny<CancellationToken>()), Times.Once);
 
+        _mockTournamentRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()), Times.Once);
         _mockDivisionRepository.Verify(repo => repo.RetrieveAsync(newDivisionId, It.IsAny<CancellationToken>()), Times.Once);
         _mockSquadRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()), Times.Once);
         _mockSweeperRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -441,8 +532,22 @@ public sealed class AppendRegistrationCommandHandlerTests
             Payments = []
         };
 
+        var tournament = new TournamentManager.Database.Entities.Tournament
+        {
+            Id = TournamentId.New(),
+            Start = new DateOnly(2024, 1, 1),
+            Sweepers =
+            [
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] },
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] }
+            ]
+        };
+
         _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
 
         _mockRegistrationValidator.Setup(validator => validator.ValidateAsync(It.IsAny<TournamentManager.Models.Registration>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new FluentValidation.Results.ValidationResult());
@@ -541,6 +646,17 @@ public sealed class AppendRegistrationCommandHandlerTests
             Payments = [existingPayment1, existingPayment2]
         };
 
+        var tournament = new TournamentManager.Database.Entities.Tournament
+        {
+            Id = TournamentId.New(),
+            Start = new DateOnly(2024, 1, 1),
+            Sweepers =
+            [
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] },
+                new() { Id = SquadId.New(), CashRatio = 1.0m, Divisions = [] }
+            ]
+        };
+
         var newDivision = new Division { Id = newDivisionId, Name = "New Division" };
         var squad1 = new TournamentSquad { Id = squadId1, Tournament = new Tournament() };
         var squad2 = new TournamentSquad { Id = squadId2, Tournament = new Tournament() };
@@ -549,6 +665,9 @@ public sealed class AppendRegistrationCommandHandlerTests
 
         _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingRegistration);
+
+        _mockTournamentRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
 
         _mockDivisionRepository.Setup(repo => repo.RetrieveAsync(newDivisionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(newDivision);
@@ -629,6 +748,7 @@ public sealed class AppendRegistrationCommandHandlerTests
             It.IsAny<CancellationToken>()), Times.Once);
 
         // Verify all repositories were called
+        _mockTournamentRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()), Times.Once);
         _mockDivisionRepository.Verify(repo => repo.RetrieveAsync(newDivisionId, It.IsAny<CancellationToken>()), Times.Once);
         _mockSquadRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()), Times.Once);
         _mockSweeperRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()), Times.Once);

--- a/source/tests/BowlingMegabucks.TournamentManager.UnitTests/Registrations/AppendRegistration/AppendRegistrationCommandHandlerTests.cs
+++ b/source/tests/BowlingMegabucks.TournamentManager.UnitTests/Registrations/AppendRegistration/AppendRegistrationCommandHandlerTests.cs
@@ -1,0 +1,636 @@
+using BowlingMegabucks.TournamentManager.Database.Entities;
+using BowlingMegabucks.TournamentManager.Registrations.AppendRegistration;
+using ErrorOr;
+using FluentValidation;
+
+namespace BowlingMegabucks.TournamentManager.UnitTests.Registrations.AppendRegistration;
+
+[TestFixture]
+public sealed class AppendRegistrationCommandHandlerTests
+{
+    private Mock<TournamentManager.Registrations.IRepository> _mockRegistrationRepository;
+    private Mock<TournamentManager.Divisions.IRepository> _mockDivisionRepository;
+    private Mock<TournamentManager.Squads.IRepository> _mockSquadRepository;
+    private Mock<TournamentManager.Sweepers.IRepository> _mockSweeperRepository;
+    private Mock<IValidator<TournamentManager.Models.Registration>> _mockRegistrationValidator;
+    private Mock<TournamentManager.Bowlers.IEntityMapper> _mockBowlerEntityMapper;
+    private Mock<TournamentManager.Registrations.IPaymentEntityMapper> _mockPaymentEntityMapper;
+
+    private AppendRegistrationCommandHandler _handler;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRegistrationRepository = new Mock<TournamentManager.Registrations.IRepository>();
+        _mockDivisionRepository = new Mock<TournamentManager.Divisions.IRepository>();
+        _mockSquadRepository = new Mock<TournamentManager.Squads.IRepository>();
+        _mockSweeperRepository = new Mock<TournamentManager.Sweepers.IRepository>();
+        _mockRegistrationValidator = new Mock<IValidator<TournamentManager.Models.Registration>>();
+        _mockBowlerEntityMapper = new Mock<TournamentManager.Bowlers.IEntityMapper>();
+        _mockPaymentEntityMapper = new Mock<TournamentManager.Registrations.IPaymentEntityMapper>();
+
+        _handler = new AppendRegistrationCommandHandler(
+            _mockRegistrationRepository.Object,
+            _mockDivisionRepository.Object,
+            _mockSquadRepository.Object,
+            _mockSweeperRepository.Object,
+            _mockRegistrationValidator.Object,
+            _mockBowlerEntityMapper.Object,
+            _mockPaymentEntityMapper.Object);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnUnexpected_WhenRegistrationCannotBeFound()
+    {
+        // Arrange
+        Registration existingRegistration = null;
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        var command = new AppendRegistrationCommand
+        {
+            Bowler = new TournamentManager.Models.Bowler { USBCId = "12345" },
+            TournamentId = TournamentId.New(),
+            DivisionId = DivisionId.New(),
+            Squads = new List<SquadId>(),
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Unexpected));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Registration.NotFound"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("The specified registration does not exist."));
+
+        _mockRegistrationRepository.Verify(repo => repo.RetrieveAsync(command.Bowler.USBCId, command.TournamentId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(),
+            It.IsAny<Bowler>(),
+            It.IsAny<DivisionId>(),
+            It.IsAny<int?>(),
+            It.IsAny<IEnumerable<SquadId>>(),
+            It.IsAny<IEnumerable<SquadId>>(),
+            It.IsAny<bool?>(),
+            It.IsAny<Payment>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnNotFound_WhenDivisionIdIsNotValid()
+    {
+        // Arrange
+        var existingRegistration = new Registration
+        {
+            Id = RegistrationId.New(),
+            Bowler = new Bowler { USBCId = "12345" },
+            DivisionId = DivisionId.New(), // Set the DivisionId property directly
+            Division = new Division { Id = DivisionId.New() },
+            Squads = [],
+            Payments = []
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockDivisionRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<DivisionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Division)null);
+
+        var command = new AppendRegistrationCommand
+        {
+            Bowler = new TournamentManager.Models.Bowler { USBCId = "12345" },
+            TournamentId = TournamentId.New(),
+            DivisionId = DivisionId.New(),
+            Squads = new List<SquadId>(),
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.NotFound));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Division.NotFound"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("The specified division does not exist."));
+
+        _mockDivisionRepository.Verify(repo => repo.RetrieveAsync(command.DivisionId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(),
+            It.IsAny<Bowler>(),
+            It.IsAny<DivisionId>(),
+            It.IsAny<int?>(),
+            It.IsAny<IEnumerable<SquadId>>(),
+            It.IsAny<IEnumerable<SquadId>>(),
+            It.IsAny<bool?>(),
+            It.IsAny<Payment>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldNotCallDivisionRepository_WhenDivisionIsSameAsExisting()
+    {
+        // Arrange
+        var divisionId = DivisionId.New();
+        var existingRegistration = new Registration
+        {
+            Id = RegistrationId.New(),
+            Bowler = new Bowler { USBCId = "12345" },
+            DivisionId = divisionId, // Set the DivisionId property directly
+            Division = new Division { Id = divisionId },
+            Squads = new List<SquadRegistration>(),
+            Payments = new List<Payment>()
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockRegistrationValidator.Setup(validator => validator.ValidateAsync(It.IsAny<TournamentManager.Models.Registration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        var command = new AppendRegistrationCommand
+        {
+            Bowler = new TournamentManager.Models.Bowler { USBCId = "12345" },
+            TournamentId = TournamentId.New(),
+            DivisionId = divisionId, // Same as existing registration
+            Squads = new List<SquadId>(),
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        _mockDivisionRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<DivisionId>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnValidationError_WhenSquadsOverlapWithExistingRegistration()
+    {
+        // Arrange
+        var existingSquadId1 = SquadId.New();
+        var existingSquadId2 = SquadId.New();
+        var overlappingSquadId = SquadId.New();
+        var divisionId = DivisionId.New();
+
+        var existingRegistration = new Registration
+        {
+            Id = RegistrationId.New(),
+            Bowler = new Bowler { USBCId = "12345" },
+            DivisionId = divisionId, // Use same division to avoid division lookup
+            Division = new Division { Id = divisionId },
+            Squads = new List<SquadRegistration>
+            {
+                new() { SquadId = existingSquadId1 },
+                new() { SquadId = existingSquadId2 },
+                new() { SquadId = overlappingSquadId }
+            },
+            Payments = []
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        var command = new AppendRegistrationCommand
+        {
+            Bowler = new TournamentManager.Models.Bowler { USBCId = "12345" },
+            TournamentId = TournamentId.New(),
+            DivisionId = divisionId, // Same division to skip division lookup
+            Squads = new List<SquadId> { SquadId.New(), overlappingSquadId }, // One overlapping squad
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Squad.Conflict"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("The specified squads are already registered."));
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(),
+            It.IsAny<Bowler>(),
+            It.IsAny<DivisionId>(),
+            It.IsAny<int?>(),
+            It.IsAny<IEnumerable<SquadId>>(),
+            It.IsAny<IEnumerable<SquadId>>(),
+            It.IsAny<bool?>(),
+            It.IsAny<Payment>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnValidationError_WhenSweepersOverlapWithExistingRegistration()
+    {
+        // Arrange
+        var existingSweeperSquadId1 = SquadId.New();
+        var existingSweeperSquadId2 = SquadId.New();
+        var overlappingSweeperSquadId = SquadId.New();
+        var divisionId = DivisionId.New();
+
+        var existingRegistration = new Registration
+        {
+            Id = RegistrationId.New(),
+            Bowler = new Bowler { USBCId = "12345" },
+            DivisionId = divisionId, // Use same division to avoid division lookup
+            Division = new Division { Id = divisionId },
+            Squads = new List<SquadRegistration>
+            {
+                new() { SquadId = existingSweeperSquadId1 },
+                new() { SquadId = existingSweeperSquadId2 },
+                new() { SquadId = overlappingSweeperSquadId }
+            },
+            Payments = []
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        var command = new AppendRegistrationCommand
+        {
+            Bowler = new TournamentManager.Models.Bowler { USBCId = "12345" },
+            TournamentId = TournamentId.New(),
+            DivisionId = divisionId, // Same division to skip division lookup
+            Squads = new List<SquadId>(), // Empty squads to focus on sweepers
+            Sweepers = new List<SquadId> { SquadId.New(), overlappingSweeperSquadId }, // One overlapping sweeper
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.FirstError.Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(result.FirstError.Code, Is.EqualTo("Sweeper.Conflict"));
+        Assert.That(result.FirstError.Description, Is.EqualTo("The specified sweepers are already registered."));
+
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(),
+            It.IsAny<Bowler>(),
+            It.IsAny<DivisionId>(),
+            It.IsAny<int?>(),
+            It.IsAny<IEnumerable<SquadId>>(),
+            It.IsAny<IEnumerable<SquadId>>(),
+            It.IsAny<bool?>(),
+            It.IsAny<Payment>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldReturnValidationErrors_WhenValidationFails()
+    {
+        // Arrange
+        var divisionId = DivisionId.New();
+        var existingRegistration = new Registration
+        {
+            Id = RegistrationId.New(),
+            Bowler = new Bowler { USBCId = "12345", FirstName = "John", LastName = "Doe" },
+            DivisionId = divisionId,
+            Division = new Division { Id = divisionId },
+            Average = 150,
+            SuperSweeper = false,
+            Squads = [],
+            Payments = []
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        // Setup validation to fail with multiple errors
+        var validationResult = new FluentValidation.Results.ValidationResult();
+        validationResult.Errors.Add(new FluentValidation.Results.ValidationFailure("Bowler.Name", "Bowler name is required") { ErrorCode = "Bowler.Name" });
+        validationResult.Errors.Add(new FluentValidation.Results.ValidationFailure("Average", "Average must be between 0 and 300") { ErrorCode = "Average" });
+        validationResult.Errors.Add(new FluentValidation.Results.ValidationFailure("Squads", "At least one squad is required") { ErrorCode = "Squads" });
+
+        _mockRegistrationValidator.Setup(validator => validator.ValidateAsync(It.IsAny<TournamentManager.Models.Registration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validationResult);
+
+        var command = new AppendRegistrationCommand
+        {
+            Bowler = new TournamentManager.Models.Bowler { USBCId = "12345", Name = new TournamentManager.Models.PersonName { First = "", Last = "" } },
+            TournamentId = TournamentId.New(),
+            DivisionId = divisionId, // Same division to skip division lookup
+            Squads = new List<SquadId>(), // Empty squads to skip squad processing
+            Sweepers = new List<SquadId>(), // Empty sweepers to skip sweeper processing
+            Average = 350,
+            SuperSweeper = false
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.True);
+        Assert.That(result.Errors.Count, Is.EqualTo(3));
+        
+        var errors = result.Errors.ToList();
+        Assert.That(errors[0].Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(errors[0].Code, Is.EqualTo("Bowler.Name"));
+        Assert.That(errors[0].Description, Is.EqualTo("Bowler name is required"));
+        
+        Assert.That(errors[1].Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(errors[1].Code, Is.EqualTo("Average"));
+        Assert.That(errors[1].Description, Is.EqualTo("Average must be between 0 and 300"));
+        
+        Assert.That(errors[2].Type, Is.EqualTo(ErrorType.Validation));
+        Assert.That(errors[2].Code, Is.EqualTo("Squads"));
+        Assert.That(errors[2].Description, Is.EqualTo("At least one squad is required"));
+
+        // Verify that division, squad, and sweeper repositories are never called when validation fails
+        _mockDivisionRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<DivisionId>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockSquadRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockSweeperRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()), Times.Never);
+        
+        // Verify that update is never called
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Registration>(),
+            It.IsAny<Bowler>(),
+            It.IsAny<DivisionId>(),
+            It.IsAny<int?>(),
+            It.IsAny<IEnumerable<SquadId>>(),
+            It.IsAny<IEnumerable<SquadId>>(),
+            It.IsAny<bool?>(),
+            It.IsAny<Payment>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldUpdateModelWithAllChanges_WhenValidatorIsCalled()
+    {
+        // Arrange
+        var existingDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+        var newSquadId1 = SquadId.New();
+        var newSquadId2 = SquadId.New();
+        var newSweeperSquadId1 = SquadId.New();
+        var newSweeperSquadId2 = SquadId.New();
+
+        var existingRegistration = new Registration
+        {
+            Id = RegistrationId.New(),
+            Bowler = new Bowler { USBCId = "12345", FirstName = "Old", LastName = "Name" },
+            DivisionId = existingDivisionId,
+            Division = new Division { Id = existingDivisionId, Name = "Old Division" },
+            Average = 150,
+            SuperSweeper = false,
+            Squads = [],
+            Payments = []
+        };
+
+        var newDivision = new Division { Id = newDivisionId, Name = "New Division" };
+        var newSquad1 = new TournamentSquad { Id = newSquadId1, Tournament = new Tournament() };
+        var newSquad2 = new TournamentSquad { Id = newSquadId2, Tournament = new Tournament() };
+        var newSweeper1 = new SweeperSquad { Id = newSweeperSquadId1, CashRatio = 1.0m, Tournament = new Tournament(), Divisions = [] };
+        var newSweeper2 = new SweeperSquad { Id = newSweeperSquadId2, CashRatio = 1.0m, Tournament = new Tournament(), Divisions = [] };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockDivisionRepository.Setup(repo => repo.RetrieveAsync(newDivisionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(newDivision);
+
+        _mockSquadRepository.Setup(repo => repo.RetrieveAsync(It.Is<IEnumerable<SquadId>>(ids => ids.Contains(newSquadId1) && ids.Contains(newSquadId2)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TournamentSquad> { newSquad1, newSquad2 });
+
+        _mockSweeperRepository.Setup(repo => repo.RetrieveAsync(It.Is<IEnumerable<SquadId>>(ids => ids.Contains(newSweeperSquadId1) && ids.Contains(newSweeperSquadId2)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SweeperSquad> { newSweeper1, newSweeper2 });
+
+        _mockRegistrationValidator.Setup(validator => validator.ValidateAsync(It.IsAny<TournamentManager.Models.Registration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        var command = new AppendRegistrationCommand
+        {
+            Bowler = new TournamentManager.Models.Bowler { USBCId = "12345", Name = new TournamentManager.Models.PersonName { First = "New", Last = "Bowler" } },
+            TournamentId = TournamentId.New(),
+            DivisionId = newDivisionId, // Different division
+            Squads = new List<SquadId> { newSquadId1, newSquadId2 },
+            Sweepers = new List<SquadId> { newSweeperSquadId1, newSweeperSquadId2 },
+            Average = 180,
+            SuperSweeper = true
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert - Verify the validator was called with the updated model
+        _mockRegistrationValidator.Verify(validator => validator.ValidateAsync(
+            It.Is<TournamentManager.Models.Registration>(reg =>
+                reg.Bowler.Name.First == "New" &&
+                reg.Bowler.Name.Last == "Bowler" &&
+                reg.Division.Id == newDivisionId &&
+                reg.Average == 180 &&
+                reg.SuperSweeper == true &&
+                reg.Squads.Count() == 2 &&
+                reg.Sweepers.Count() == 2),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        _mockDivisionRepository.Verify(repo => repo.RetrieveAsync(newDivisionId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockSquadRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockSweeperRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldAddPaymentToEntity_WhenPaymentIsProvided()
+    {
+        // Arrange
+        var divisionId = DivisionId.New();
+        var existingRegistration = new Registration
+        {
+            Id = RegistrationId.New(),
+            Bowler = new Bowler { USBCId = "12345", FirstName = "John", LastName = "Doe" },
+            DivisionId = divisionId,
+            Division = new Division { Id = divisionId },
+            Average = 150,
+            SuperSweeper = false,
+            Squads = [],
+            Payments = []
+        };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockRegistrationValidator.Setup(validator => validator.ValidateAsync(It.IsAny<TournamentManager.Models.Registration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        _mockBowlerEntityMapper.Setup(mapper => mapper.Execute(It.IsAny<TournamentManager.Models.Bowler>()))
+            .Returns(new Bowler());
+
+        var paymentEntity = new Payment { Amount = 100.50m, ConfirmationCode = "TEST123" };
+        _mockPaymentEntityMapper.Setup(mapper => mapper.Execute(It.IsAny<TournamentManager.Models.Payment>()))
+            .Returns(paymentEntity);
+
+        var payment = new TournamentManager.Models.Payment
+        {
+            Amount = 100.50m,
+            ConfirmationCode = "TEST123"
+        };
+
+        var command = new AppendRegistrationCommand
+        {
+            Bowler = new TournamentManager.Models.Bowler { USBCId = "12345", Name = new TournamentManager.Models.PersonName { First = "John", Last = "Doe" } },
+            TournamentId = TournamentId.New(),
+            DivisionId = divisionId, // Same division to skip division lookup
+            Squads = new List<SquadId>(), // Empty squads to skip squad processing
+            Sweepers = new List<SquadId>(), // Empty sweepers to skip sweeper processing
+            Payment = payment
+        };
+
+        var timestampBefore = DateTime.UtcNow;
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        var timestampAfter = DateTime.UtcNow;
+
+        // Assert
+        Assert.That(result.IsError, Is.False);
+
+        // Verify that CreatedAtUtc timestamp was set on the payment
+        Assert.That(payment.CreatedAtUtc, Is.GreaterThanOrEqualTo(timestampBefore));
+        Assert.That(payment.CreatedAtUtc, Is.LessThanOrEqualTo(timestampAfter));
+
+        // Verify that the payment entity mapper was called with the payment
+        _mockPaymentEntityMapper.Verify(mapper => mapper.Execute(payment), Times.Once);
+
+        // Verify that UpdateAsync was called with the payment entity
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(
+            It.IsAny<Registration>(),
+            It.IsAny<Bowler>(),
+            It.IsAny<DivisionId>(),
+            It.IsAny<int?>(),
+            It.IsAny<IEnumerable<SquadId>>(),
+            It.IsAny<IEnumerable<SquadId>>(),
+            It.IsAny<bool?>(),
+            paymentEntity, // Verify the specific payment entity is passed
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldUpdateEverythingCorrectly_WhenAllChangesProvided()
+    {
+        // Arrange
+        var existingRegistrationId = RegistrationId.New();
+        var existingDivisionId = DivisionId.New();
+        var newDivisionId = DivisionId.New();
+        var squadId1 = SquadId.New();
+        var squadId2 = SquadId.New();
+        var sweeperSquadId1 = SquadId.New();
+        var sweeperSquadId2 = SquadId.New();
+
+        var existingSquadId1 = SquadId.New();
+        var existingSquadId2 = SquadId.New();
+        var existingSquadReg1 = new SquadRegistration 
+        { 
+            RegistrationId = existingRegistrationId, 
+            SquadId = existingSquadId1,
+            Squad = new TournamentSquad { Id = existingSquadId1 }
+        };
+        var existingSquadReg2 = new SquadRegistration 
+        { 
+            RegistrationId = existingRegistrationId, 
+            SquadId = existingSquadId2,
+            Squad = new SweeperSquad { Id = existingSquadId2, CashRatio = 1.0m }
+        };
+        var existingPayment1 = new Payment { Id = PaymentId.New(), Amount = 50.00m, ConfirmationCode = "PAY123" };
+        var existingPayment2 = new Payment { Id = PaymentId.New(), Amount = 25.00m, ConfirmationCode = "PAY789" };
+
+        var existingRegistration = new Registration
+        {
+            Id = existingRegistrationId,
+            Bowler = new Bowler { USBCId = "12345", FirstName = "Old", LastName = "Name" },
+            DivisionId = existingDivisionId,
+            Division = new Division { Id = existingDivisionId },
+            Average = 150,
+            SuperSweeper = false,
+            Squads = [existingSquadReg1, existingSquadReg2],
+            Payments = [existingPayment1, existingPayment2]
+        };
+
+        var newDivision = new Division { Id = newDivisionId, Name = "New Division" };
+        var squad1 = new TournamentSquad { Id = squadId1, Tournament = new Tournament() };
+        var squad2 = new TournamentSquad { Id = squadId2, Tournament = new Tournament() };
+        var sweeper1 = new SweeperSquad { Id = sweeperSquadId1, CashRatio = 1.0m, Tournament = new Tournament(), Divisions = [] };
+        var sweeper2 = new SweeperSquad { Id = sweeperSquadId2, CashRatio = 1.0m, Tournament = new Tournament(), Divisions = [] };
+
+        _mockRegistrationRepository.Setup(repo => repo.RetrieveAsync(It.IsAny<string>(), It.IsAny<TournamentId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegistration);
+
+        _mockDivisionRepository.Setup(repo => repo.RetrieveAsync(newDivisionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(newDivision);
+
+        _mockSquadRepository.Setup(repo => repo.RetrieveAsync(It.Is<IEnumerable<SquadId>>(ids => ids.Contains(squadId1) && ids.Contains(squadId2)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TournamentSquad> { squad1, squad2 });
+
+        _mockSweeperRepository.Setup(repo => repo.RetrieveAsync(It.Is<IEnumerable<SquadId>>(ids => ids.Contains(sweeperSquadId1) && ids.Contains(sweeperSquadId2)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SweeperSquad> { sweeper1, sweeper2 });
+
+        _mockRegistrationValidator.Setup(validator => validator.ValidateAsync(It.IsAny<TournamentManager.Models.Registration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        var bowlerEntity = new Bowler { Id = BowlerId.New(), USBCId = "12345", FirstName = "New", LastName = "Bowler" };
+        _mockBowlerEntityMapper.Setup(mapper => mapper.Execute(It.IsAny<TournamentManager.Models.Bowler>()))
+            .Returns(bowlerEntity);
+
+        var paymentEntity = new Payment { Amount = 75.00m, ConfirmationCode = "PAY456" };
+        _mockPaymentEntityMapper.Setup(mapper => mapper.Execute(It.IsAny<TournamentManager.Models.Payment>()))
+            .Returns(paymentEntity);
+
+        var payment = new TournamentManager.Models.Payment
+        {
+            Amount = 75.00m,
+            ConfirmationCode = "PAY456"
+        };
+
+        var command = new AppendRegistrationCommand
+        {
+            Bowler = new TournamentManager.Models.Bowler { USBCId = "12345", Name = new TournamentManager.Models.PersonName { First = "New", Last = "Bowler" } },
+            TournamentId = TournamentId.New(),
+            DivisionId = newDivisionId,
+            Squads = new List<SquadId> { squadId1, squadId2 },
+            Sweepers = new List<SquadId> { sweeperSquadId1, sweeperSquadId2 },
+            Average = 185,
+            SuperSweeper = true,
+            Payment = payment
+        };
+
+        // Act
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsError, Is.False);
+        Assert.That(result.Value, Is.EqualTo(existingRegistrationId));
+
+        // Verify the existing registration entity is not modified - squads and payments remain unchanged
+        Assert.That(existingRegistration.Squads.Count, Is.EqualTo(2));
+        Assert.That(existingRegistration.Squads.First().SquadId, Is.EqualTo(existingSquadId1));
+        Assert.That(existingRegistration.Squads.Last().SquadId, Is.EqualTo(existingSquadId2));
+        Assert.That(existingRegistration.Payments.Count, Is.EqualTo(2));
+        Assert.That(existingRegistration.Payments.First().ConfirmationCode, Is.EqualTo("PAY123"));
+        Assert.That(existingRegistration.Payments.Last().ConfirmationCode, Is.EqualTo("PAY789"));
+
+        // Verify bowler entity mapper was called with the correct bowler
+        _mockBowlerEntityMapper.Verify(mapper => mapper.Execute(
+            It.Is<TournamentManager.Models.Bowler>(b => 
+                b.USBCId == "12345" && 
+                b.Name.First == "New" && 
+                b.Name.Last == "Bowler")), Times.Once);
+
+        // Verify payment timestamp was set
+        Assert.That(payment.CreatedAtUtc, Is.Not.EqualTo(default(DateTime)));
+
+        // Verify payment entity mapper was called
+        _mockPaymentEntityMapper.Verify(mapper => mapper.Execute(payment), Times.Once);
+
+        // Verify registration repository UpdateAsync was called with all correct parameters
+        _mockRegistrationRepository.Verify(repo => repo.UpdateAsync(
+            existingRegistration,           // The existing registration entity
+            bowlerEntity,                   // The mapped bowler entity  
+            newDivisionId,                  // The new division ID
+            185,                           // The new average
+            It.Is<IEnumerable<SquadId>>(squads => squads.Contains(squadId1) && squads.Contains(squadId2)), // Squad IDs
+            It.Is<IEnumerable<SquadId>>(sweepers => sweepers.Contains(sweeperSquadId1) && sweepers.Contains(sweeperSquadId2)), // Sweeper IDs
+            true,                          // Super sweeper flag
+            paymentEntity,                 // The mapped payment entity
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        // Verify all repositories were called
+        _mockDivisionRepository.Verify(repo => repo.RetrieveAsync(newDivisionId, It.IsAny<CancellationToken>()), Times.Once);
+        _mockSquadRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockSweeperRepository.Verify(repo => repo.RetrieveAsync(It.IsAny<IEnumerable<SquadId>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
This pull request introduces the ability to append to an existing registration (such as adding squads, sweepers, or payments) when a registration conflict is detected, rather than simply returning an error. It adds a new command and handler for this operation, integrates it into the API endpoint, and updates the registration repository and model logic to support these changes. Additionally, it improves the handling of the `SuperSweeper` property and adds telemetry/logging for the append operation.

**Append Registration Feature**

* Added `AppendRegistrationCommand` and its handler (`AppendRegistrationCommandHandler`) to allow updating an existing registration by appending squads, sweepers, or payments, instead of failing on conflict. The handler includes validation to prevent duplicate squads or sweepers and ensures correct updates to the registration. [[1]](diffhunk://#diff-2af2f1db06dcc8a76af53cdd696915acbba65088f997689ccae103951cc0d7a1R1-R50) [[2]](diffhunk://#diff-ad6d684890437dc26ec585725d4a2f6d778c58c00868a5fc7af60d1e859385a6R1-R133)
* Introduced a telemetry/logging decorator for the append handler to provide detailed logging and tracing of append operations.
* Registered the new append command handler and its decorator in the dependency injection container.

**API Endpoint Changes**

* Updated the `CreateRegistrationEndpoint` to invoke the append registration logic when a registration conflict is detected, returning the appropriate response or error. This includes changes to the constructor, dependency injection, and request handling logic. [[1]](diffhunk://#diff-f983cdd2fa1072bf78d0611f55ddc0f5673f43af283c017e72fe763b8d84890aR6) [[2]](diffhunk://#diff-f983cdd2fa1072bf78d0611f55ddc0f5673f43af283c017e72fe763b8d84890aR57-R69) [[3]](diffhunk://#diff-f983cdd2fa1072bf78d0611f55ddc0f5673f43af283c017e72fe763b8d84890aL101-R137)

**Registration Repository and Model Enhancements**

* Extended the registration repository with methods to retrieve a registration by bowler and tournament, and to update an existing registration with new squads, sweepers, or payments. [[1]](diffhunk://#diff-40ee0384536cb038538517b4c47de775a2f3097f1521d6f30ea4833adad92114R63-R70) [[2]](diffhunk://#diff-40ee0384536cb038538517b4c47de775a2f3097f1521d6f30ea4833adad92114R135-R184)
* Added helper methods to the registration model for appending squads, sweepers, and payments.

**Other Improvements**

* Improved handling of the `SuperSweeper` property to allow `null` values, clarifying the meaning of `null` for both new and existing registrations. [[1]](diffhunk://#diff-34cbaa05aa3a7ad3b769fbab247181f399b02d62b1a68375cc3455237a662485R43-R46) [[2]](diffhunk://#diff-949cd225a204dde11ae50f8611dc794a2214aea3701d377003473d8dbed63867L83-R83)
* Fixed gender mapping in `BowlerInput` to directly map "M" to `Male` and otherwise to `Female`.