### PR TITLE
Add global exception handling middleware

### DIFF
--- a/source/api/Middleware/GlobalExceptionMiddleware.cs
+++ b/source/api/Middleware/GlobalExceptionMiddleware.cs
@@ -1,0 +1,59 @@
+using System.Net;
+
+namespace BowlingMegabucks.TournamentManager.Api.Middleware;
+
+internal sealed class GlobalExceptionMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<GlobalExceptionMiddleware> _logger;
+
+    public GlobalExceptionMiddleware(RequestDelegate next, ILogger<GlobalExceptionMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogUnhandledException(ex);
+
+            if (!context.Response.HasStarted)
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                context.Response.ContentType = "application/problem+json";
+
+                var problemDetails = new Microsoft.AspNetCore.Mvc.ProblemDetails
+                {
+                    Title = "An error occurred",
+                    Detail = "An unexpected error occurred while processing your request.",
+                    Status = (int)HttpStatusCode.InternalServerError,
+                    Instance = context.Request.Path,
+                    Extensions =
+                    {
+                        ["traceId"] = context.TraceIdentifier
+                    }
+                };
+
+                await context.Response.WriteAsJsonAsync(problemDetails);
+            }
+        }
+    }
+}
+
+internal static partial class GlobalExceptionLogMessages
+{
+    [LoggerMessage(Level = LogLevel.Error, Message = "An unhandled exception occurred while processing the request")]
+    public static partial void LogUnhandledException(this ILogger<GlobalExceptionMiddleware> logger, Exception ex);
+}
+
+internal static class GlobalExceptionMiddlewareExtensions
+{
+    public static IApplicationBuilder UseGlobalExceptionHandler(this IApplicationBuilder app)
+        => app.UseMiddleware<GlobalExceptionMiddleware>();
+}

--- a/source/api/Program.cs
+++ b/source/api/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authentication;
 using BowlingMegabucks.TournamentManager;
 using BowlingMegabucks.TournamentManager.Api.Authentication;
 using BowlingMegabucks.TournamentManager.Api.Extensions;
+using BowlingMegabucks.TournamentManager.Api.Middleware;
 using BowlingMegabucks.TournamentManager.Database;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -29,6 +30,8 @@ builder.AddHealthChecks();
 builder.AddOpenTelemetry();
 
 var app = builder.Build();
+
+app.UseGlobalExceptionHandler();
 
 app.UseLogging();
 

--- a/source/api/Program.cs
+++ b/source/api/Program.cs
@@ -31,10 +31,9 @@ builder.AddOpenTelemetry();
 
 var app = builder.Build();
 
-app.UseGlobalExceptionHandler();
-
 app.UseLogging();
 
+app.UseGlobalExceptionHandler();
 app.UseApiRateLimiting();
 
 app.MapApiHealthChecks();


### PR DESCRIPTION
This pull request introduces a centralized global exception handling middleware to the API, improving error handling and logging for unhandled exceptions. The middleware ensures that unexpected errors are consistently logged and returned to clients in a standardized format. The changes also integrate this middleware into the application's startup pipeline.

**Global Exception Handling:**

* Added `GlobalExceptionMiddleware` in `Middleware/GlobalExceptionMiddleware.cs` to catch unhandled exceptions, log them, and return a standardized `problem+json` response with trace information.
* Implemented an extension method `UseGlobalExceptionHandler` for easy integration of the middleware into the request pipeline.

**Application Startup Integration:**

* Registered the global exception middleware in `Program.cs` by calling `app.UseGlobalExceptionHandler()` before other middlewares.
* Imported the middleware namespace in `Program.cs` to enable usage of the new exception handler.